### PR TITLE
mrc-3044 set time, reset stepper

### DIFF
--- a/inst/include/mode/mode.hpp
+++ b/inst/include/mode/mode.hpp
@@ -6,12 +6,12 @@
 namespace mode {
 
 // Models need to bring their own implementation here
-template<typename T>
+template <typename T>
 typename mode::pars_type<T> mode_pars(cpp11::list pars);
 
 // TODO: consider a better name here, but using the same name as the
 // namespace does not end well...
-template<typename T>
+template <typename T>
 class container {
 public:
   using model_type = T;
@@ -68,7 +68,7 @@ private:
   // because otherwise we need to implement a default constructor for
   // the solver (something which we will then never use once we have
   // more than one system).
-  std::vector <solver<model_type>> solver_;
+  std::vector<solver<model_type>> solver_;
   size_t n_particles_;
   model_type m_;
 };

--- a/inst/include/mode/mode.hpp
+++ b/inst/include/mode/mode.hpp
@@ -6,26 +6,27 @@
 namespace mode {
 
 // Models need to bring their own implementation here
-template <typename T>
+template<typename T>
 typename mode::pars_type<T> mode_pars(cpp11::list pars);
 
 // TODO: consider a better name here, but using the same name as the
 // namespace does not end well...
-template <typename T>
+template<typename T>
 class container {
 public:
   using model_type = T;
   using pars_type = mode::pars_type<T>;
 
-  container(const pars_type& pars, const double time,
-            const size_t n_particles): n_particles_(n_particles) {
+  container(const pars_type &pars, const double time,
+            const size_t n_particles) : n_particles_(n_particles),
+                                        m_(model_type(pars)) {
     // This will get considerably more complicated once we move to
     // support multiple particles, and following the general approach
     // in dust will be sensible, I think.
-    auto m = model_type(pars);
     auto ctl = control();
+    auto y = m_.initial(time);
     for (size_t i = 0; i < n_particles; ++i) {
-      solver_.push_back(solver<model_type>(m, time, ctl));
+      solver_.push_back(solver<model_type>(m_, time, y, ctl));
     }
   }
 
@@ -47,7 +48,7 @@ public:
     }
   }
 
-  void state(std::vector<double>& end_state) {
+  void state(std::vector<double> &end_state) {
     auto it = end_state.begin();
     for (size_t i = 0; i < n_particles_; ++i) {
       it = solver_[i].state(it);
@@ -55,8 +56,9 @@ public:
   }
 
   void set_time(double time) {
+    auto y = m_.initial(time);
     for (size_t i = 0; i < n_particles_; ++i) {
-      solver_[i].set_time(time);
+      solver_[i].reset(time, y);
     }
   }
 
@@ -66,8 +68,9 @@ private:
   // because otherwise we need to implement a default constructor for
   // the solver (something which we will then never use once we have
   // more than one system).
-  std::vector<solver<model_type>> solver_;
+  std::vector <solver<model_type>> solver_;
   size_t n_particles_;
+  model_type m_;
 };
 
 }

--- a/inst/include/mode/mode.hpp
+++ b/inst/include/mode/mode.hpp
@@ -23,10 +23,9 @@ public:
     // support multiple particles, and following the general approach
     // in dust will be sensible, I think.
     auto m = model_type(pars);
-    auto y = m.initial(time);
     auto ctl = control();
     for (size_t i = 0; i < n_particles; ++i) {
-      solver_.push_back(solver<model_type>(m, time, y, ctl));
+      solver_.push_back(solver<model_type>(m, time, ctl));
     }
   }
 
@@ -52,6 +51,12 @@ public:
     auto it = end_state.begin();
     for (size_t i = 0; i < n_particles_; ++i) {
       it = solver_[i].state(it);
+    }
+  }
+
+  void set_time(double time) {
+    for (size_t i = 0; i < n_particles_; ++i) {
+      solver_[i].set_time(time);
     }
   }
 

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -13,6 +13,14 @@
 namespace mode {
 namespace r {
 
+double validate_time(cpp11::sexp r_time) {
+  cpp11::doubles time = cpp11::as_cpp<cpp11::doubles>(r_time);
+  if (time.size() > 1) {
+    cpp11::stop("Time should be a scalar value");
+  }
+  return time[0];
+}
+
 template <typename T>
 cpp11::list mode_alloc(cpp11::list r_pars, double time, size_t n_particles) {
   auto pars = mode::mode_pars<T>(r_pars);
@@ -52,6 +60,15 @@ cpp11::sexp mode_solve(SEXP ptr, double end_time) {
   std::vector<double> dat(obj->n_state() * obj->n_particles());
   obj->state(dat);
   return state_array(dat, obj->n_state(), obj->n_particles());
+}
+
+template <typename T>
+void mode_update_state(SEXP ptr, SEXP r_time) {
+  T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
+  if (r_time != R_NilValue) {
+    auto time = validate_time(r_time);
+    obj->set_time(time);
+  }
 }
 
 }

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -56,7 +56,7 @@ cpp11::sexp mode_solve(SEXP ptr, double end_time) {
 
 double validate_time(cpp11::sexp r_time) {
   cpp11::doubles time = cpp11::as_cpp<cpp11::doubles>(r_time);
-  if (time.size() > 1) {
+  if (time.size() != 1) {
     cpp11::stop("expected 'time' to be a scalar value");
   }
   return time[0];

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -13,14 +13,6 @@
 namespace mode {
 namespace r {
 
-double validate_time(cpp11::sexp r_time) {
-  cpp11::doubles time = cpp11::as_cpp<cpp11::doubles>(r_time);
-  if (time.size() > 1) {
-    cpp11::stop("Time should be a scalar value");
-  }
-  return time[0];
-}
-
 template <typename T>
 cpp11::list mode_alloc(cpp11::list r_pars, double time, size_t n_particles) {
   auto pars = mode::mode_pars<T>(r_pars);
@@ -60,6 +52,14 @@ cpp11::sexp mode_solve(SEXP ptr, double end_time) {
   std::vector<double> dat(obj->n_state() * obj->n_particles());
   obj->state(dat);
   return state_array(dat, obj->n_state(), obj->n_particles());
+}
+
+double validate_time(cpp11::sexp r_time) {
+  cpp11::doubles time = cpp11::as_cpp<cpp11::doubles>(r_time);
+  if (time.size() > 1) {
+    cpp11::stop("time should be a scalar value");
+  }
+  return time[0];
 }
 
 template <typename T>

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -57,7 +57,7 @@ cpp11::sexp mode_solve(SEXP ptr, double end_time) {
 double validate_time(cpp11::sexp r_time) {
   cpp11::doubles time = cpp11::as_cpp<cpp11::doubles>(r_time);
   if (time.size() > 1) {
-    cpp11::stop("time should be a scalar value");
+    cpp11::stop("expected 'time' to be a scalar value");
   }
   return time[0];
 }

--- a/inst/include/mode/solver.hpp
+++ b/inst/include/mode/solver.hpp
@@ -20,12 +20,13 @@ private:
   stepper<Model> stepper_;
   size_t size_;
 public:
-  solver(Model m, double t, control ctl) : m_(m),
-                                           t_(t),
-                                           ctl_(ctl),
-                                           stepper_(m),
-                                           size_(m.size()) {
-    reset(t);
+  solver(Model m, double t, std::vector<double> y, control ctl) : m_(m),
+                                                                  t_(t),
+                                                                  ctl_(ctl),
+                                                                  stepper_(m),
+                                                                  size_(
+                                                                      m.size()) {
+    reset(t, y);
   }
 
   double time() const {
@@ -98,12 +99,7 @@ public:
     }
   }
 
-  void set_time(double t) {
-    reset(t);
-  }
-
-  void reset(double t) {
-    auto y = m_.initial(t);
+  void reset(double t, std::vector<double> y) {
     stepper_.reset(t, y);
     stats_.reset();
     h_ = initial_step_size(m_, t, y, ctl_);

--- a/inst/template/mode.R.template
+++ b/inst/template/mode.R.template
@@ -35,5 +35,10 @@
 
     solve = function(end_time) {
       mode_{{name}}_solve(private$ptr_, end_time)
+    },
+
+    update_state = function(time) {
+      mode_{{name}}_update_state(private$ptr_, time)
     }
+
   ))

--- a/inst/template/mode.R.template
+++ b/inst/template/mode.R.template
@@ -37,7 +37,8 @@
       mode_{{name}}_solve(private$ptr_, end_time)
     },
 
-    update_state = function(time) {
+    update_state = function(pars = NULL, state = NULL, time = NULL,
+                            set_initial_state = NULL) {
       mode_{{name}}_update_state(private$ptr_, time)
     }
 

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -16,3 +16,8 @@ double mode_{{name}}_time(SEXP ptr) {
 cpp11::sexp mode_{{name}}_solve(SEXP ptr, int end_time) {
   return mode::r::mode_solve<mode::container<{{class}}>>(ptr, end_time);
 }
+
+[[cpp11::register]]
+void mode_{{name}}_update_state(SEXP ptr, SEXP time) {
+  return mode::r::mode_update_state<mode::container<{{class}}>>(ptr, time);
+}

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -80,6 +80,6 @@ test_that("Can only update time for all particles at once", {
   n_particles <- 5
   initial_time <- 1
   mod <- gen$new(pars, initial_time, n_particles)
-  expect_error(mod$update_state(c(1, 2, 3, 4, 5)),
+  expect_error(mod$update_state(time = c(1, 2, 3, 4, 5)),
                "expected 'time' to be a scalar value")
 })

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -57,7 +57,6 @@ test_that("cache hits don't compile", {
   expect_identical(gen3, gen)
 })
 
-
 test_that("Can update time", {
   path <- mode_file("examples/logistic.cpp")
   gen <- mode(path, quiet = TRUE)
@@ -72,4 +71,15 @@ test_that("Can update time", {
   expect_equal(mod$time(), initial_time)
   res2 <- mod$solve(5)
   expect_equal(res, res2)
+})
+
+test_that("Can only update time for all particles at once", {
+  path <- mode_file("examples/logistic.cpp")
+  gen <- mode(path, quiet = TRUE)
+  pars <- list(r1 = 0.1, r2 = 0.2, K1 = 100, K2 = 100)
+  n_particles <- 5
+  initial_time <- 1
+  mod <- gen$new(pars, initial_time, n_particles)
+  expect_error(mod$update_state(c(1, 2, 3, 4, 5)),
+               "time should be a scalar value")
 })

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -32,7 +32,6 @@ test_that("End time must be later than initial time", {
   expect_error(mod$solve(2), e, fixed = TRUE)
 })
 
-
 test_that("cache hits don't compile", {
   skip_if_not_installed("mockery")
 
@@ -56,4 +55,21 @@ test_that("cache hits don't compile", {
   gen3 <- mode(path, quiet = TRUE, skip_cache = TRUE)
   mockery::expect_called(mock_compile_mode, 1)
   expect_identical(gen3, gen)
+})
+
+
+test_that("Can update time", {
+  path <- mode_file("examples/logistic.cpp")
+  gen <- mode(path, quiet = TRUE)
+  pars <- list(r1 = 0.1, r2 = 0.2, K1 = 100, K2 = 100)
+  n_particles <- 10
+  initial_time <- 1
+  mod <- gen$new(pars, initial_time, n_particles)
+  expect_equal(mod$time(), initial_time)
+  res <- mod$solve(5)
+  expect_equal(mod$time(), 5)
+  mod$update_state(initial_time)
+  expect_equal(mod$time(), initial_time)
+  res2 <- mod$solve(5)
+  expect_equal(res, res2)
 })

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -67,7 +67,7 @@ test_that("Can update time", {
   expect_equal(mod$time(), initial_time)
   res <- mod$solve(5)
   expect_equal(mod$time(), 5)
-  mod$update_state(initial_time)
+  mod$update_state(time = initial_time)
   expect_equal(mod$time(), initial_time)
   res2 <- mod$solve(5)
   expect_equal(res, res2)

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -70,7 +70,7 @@ test_that("Can update time", {
   mod$update_state(initial_time)
   expect_equal(mod$time(), initial_time)
   res2 <- mod$solve(5)
-  expect_equal(res, res2)
+  expect_identical(res, res2)
 })
 
 test_that("Can only update time for all particles at once", {
@@ -81,5 +81,5 @@ test_that("Can only update time for all particles at once", {
   initial_time <- 1
   mod <- gen$new(pars, initial_time, n_particles)
   expect_error(mod$update_state(c(1, 2, 3, 4, 5)),
-               "time should be a scalar value")
+               "expected 'time' to be a scalar value")
 })


### PR DESCRIPTION
Adds a new `update_state` function that at the moment just accepts `time` as an arg, but will later include `state` and `pars` as per the dust interface.