### PR TITLE
Fix type of time

### DIFF
--- a/inst/include/mode/mode.hpp
+++ b/inst/include/mode/mode.hpp
@@ -57,7 +57,7 @@ public:
     return solver_[0].time();
   }
 
-  void run(int end_time) {
+  void run(double end_time) {
     for (size_t i = 0; i < n_particles_; ++i) {
       solver_[i].solve(end_time);
     }

--- a/inst/include/mode/solver.hpp
+++ b/inst/include/mode/solver.hpp
@@ -100,7 +100,7 @@ public:
     return t_;
   }
 
-  void solve(int t) {
+  void solve(double t) {
     while (t_ < t) {
       step(t);
     }

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -13,7 +13,7 @@ double mode_{{name}}_time(SEXP ptr) {
 }
 
 [[cpp11::register]]
-cpp11::sexp mode_{{name}}_run(SEXP ptr, int end_time) {
+cpp11::sexp mode_{{name}}_run(SEXP ptr, double end_time) {
   return mode::r::mode_run<mode::container<{{class}}>>(ptr, end_time);
 }
 

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -234,3 +234,18 @@ test_that("Can get model size", {
   expect_equal(mod$n_state(), 1)
   expect_equal(mod$n_state_full(), 2)
 })
+
+
+test_that("can run to noninteger time", {
+  path <- mode_file("examples/logistic.cpp")
+  gen <- mode(path, quiet = TRUE)
+  pars <- list(r1 = 0.1, r2 = 0.2, K1 = 100, K2 = 100)
+  mod <- gen$new(pars, 0, 1)
+
+  t <- 3.95
+
+  y <- mod$run(t)
+  expect_equal(mod$time(), t)
+  expect_equal(y, logistic_analytic(c(0.1, 0.2), c(100, 100), t, c(1, 1)),
+               tolerance = 1e-7)
+})


### PR DESCRIPTION
Noticed this while thinking about times of the stochastic events - we should be able to run to any real-valued time (not just integer values)