### PR TITLE
Start on stochastic support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ BugReports: https://github.com/mrc-ide/mode/issues
 Imports:
     R6,
     cpp11,
+    dust,
     glue,
     pkgbuild (>= 1.2.0),
     pkgload
@@ -27,3 +28,5 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 SystemRequirements: C++11
+Remotes:
+    mrc-ide/dust

--- a/inst/examples/stochastic.cpp
+++ b/inst/examples/stochastic.cpp
@@ -9,6 +9,7 @@ public:
     double K1;
     double r2;
     double K2;
+    double v;
   };
 
   logistic(const mode::pars_type<logistic>& pars): shared(pars.shared) {
@@ -19,21 +20,30 @@ public:
            std::vector<double> &dydt) const {
     const double N1 = y[0];
     const double N2 = y[1];
-    dydt[0] = shared->r1 * N1 * (1 - N1 / shared->K1);
-    dydt[1] = shared->r2 * N2 * (1 - N2 / shared->K2);
-  }
+    const double w  = y[2];
+    dydt[0] = shared->r1 * N1 * (1 - N1 / (shared->K1 * w));
+    dydt[1] = shared->r2 * N2 * (1 - N2 / (shared->K2 * w));
 
-  std::vector<double> initial(double time) {
-    std::vector<double> ret = {1, 1};
-    return ret;
+    // For now we just keep the stochastic component within the same
+    // general vector, but it might be better to have a separate
+    // argument here that holds the stochastic part (that does
+    // complicate initialisation slightly, but not impossibly).
+    dydt[2] = 0;
   }
 
   void update_stochastic(double t, std::vector<double>& y,
                          rng_state_type& rng_state) {
+    const double r = dust::random::normal<double>(rng_state, 0, shared->v);
+    y[2] *= std::exp(r);
+  }
+
+  std::vector<double> initial(double time) {
+    std::vector<double> ret = {1, 1, 1};
+    return ret;
   }
 
   size_t size() const {
-    return 2;
+    return 3;
   }
 
 private:
@@ -48,8 +58,9 @@ mode::pars_type<logistic> mode_pars<logistic>(cpp11::list pars) {
   double K1 = cpp11::as_cpp<double>(pars["K1"]);
   double r2 = cpp11::as_cpp<double>(pars["r2"]);
   double K2 = cpp11::as_cpp<double>(pars["K2"]);
+  double v = cpp11::as_cpp<double>(pars["v"]);
 
-  logistic::shared_type shared{r1, K1, r2, K2};
+  logistic::shared_type shared{r1, K1, r2, K2, v};
   return mode::pars_type<logistic>(shared);
 }
 

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -56,8 +56,8 @@ void mode_set_stochastic_schedule(SEXP ptr, cpp11::sexp r_time) {
     time = cpp11::as_cpp<std::vector<double>>(cpp11::as_doubles(r_time));
     for (size_t i = 1; i < time.size(); ++i) {
       if (time[i] <= time[i - 1]) {
-        cpp11::stop("stochastic schedule must be strictly increasing (see %d)",
-                    i);
+        cpp11::stop("schedule must be strictly increasing; see time[%d]",
+                    i + 1);
       }
     }
   }

--- a/inst/include/mode/stepper.hpp
+++ b/inst/include/mode/stepper.hpp
@@ -61,6 +61,7 @@ private:
   std::vector<double> k6;
 
 public:
+  using rng_state_type = typename Model::rng_state_type;
 
   stepper(Model m) : m(m), n(m.size()), y(n), y_next(n), y_stiff(n), k1(n),
                      k2(n), k3(n), k4(n), k5(n), k6(n) {}
@@ -149,6 +150,11 @@ public:
 
   void initialise(double t) {
     m.rhs(t, y, k1);
+  }
+
+  void update_stochastic(double t, rng_state_type& rng_state) {
+    m.update_stochastic(t, y, rng_state);
+    initialise(t); // must recalculate dydt at this point
   }
 
   void step_complete(double t, double h) {

--- a/inst/template/DESCRIPTION
+++ b/inst/template/DESCRIPTION
@@ -1,4 +1,4 @@
 Package: {{base}}
-LinkingTo: cpp11
+LinkingTo: cpp11, dust
 Version: 0.0.1
 SystemRequirements: C++11

--- a/inst/template/mode.R.template
+++ b/inst/template/mode.R.template
@@ -11,8 +11,8 @@
   ),
 
   public = list(
-    initialize = function(pars, time, n_particles) {
-      res <- mode_{{name}}_alloc(pars, time, n_particles)
+    initialize = function(pars, time, n_particles, seed = NULL) {
+      res <- mode_{{name}}_alloc(pars, time, n_particles, seed)
       private$ptr_ <- res[[1]]
       private$pars_ <- pars
       private$n_particles_ <- n_particles
@@ -37,6 +37,11 @@
     set_index = function(index) {
       mode_{{name}}_set_index(private$ptr_, index)
       private$index_ <- index
+      invisible()
+    },
+
+    set_stochastic_schedule = function(time) {
+      mode_{{name}}_set_stochastic_schedule(private$ptr_, time)
       invisible()
     },
 

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -3,8 +3,9 @@
 {{model}}
 
 [[cpp11::register]]
-SEXP mode_{{name}}_alloc(cpp11::list r_pars, double time, size_t n_particles) {
-  return mode::r::mode_alloc<{{class}}>(r_pars, time, n_particles);
+SEXP mode_{{name}}_alloc(cpp11::list r_pars, double time, size_t n_particles,
+                         cpp11::sexp seed) {
+  return mode::r::mode_alloc<{{class}}>(r_pars, time, n_particles, seed);
 }
 
 [[cpp11::register]]
@@ -47,6 +48,11 @@ void mode_{{name}}_update_state(SEXP ptr,
 [[cpp11::register]]
 void mode_{{name}}_set_index(SEXP ptr, SEXP index) {
   return mode::r::mode_set_index<mode::container<{{class}}>>(ptr, index);
+}
+
+[[cpp11::register]]
+void mode_{{name}}_set_stochastic_schedule(SEXP ptr, SEXP time) {
+  return mode::r::mode_set_stochastic_schedule<mode::container<{{class}}>>(ptr, time);
 }
 
 [[cpp11::register]]


### PR DESCRIPTION
This is much less nasty than I had thought, actually.

The bookkeeping here follows dust; we could store the rng state at the particle level (i.e., in stepper) but instead we keep it in our `prng` class and have the container pass the appropriate state through to the stepper via the solver. This keeps the pattern close to dust, but also means that implementing support for get/set of rng state will be easy.

The user defines a "stochastic schedule"; stochastic events will happen at `t + eps`, following discussion with Patrick on the group chat.  So if we run through to time `t` and event will not trigger, but as soon as we go *past* `t` then it will trigger. This is important for the filtering.

Each model declares a type for the rng state type they want to use (this is a complication that is important for some stochastic models but will not be a big deal here and the one used in the examples will be a reasonable one to use everywhere), and also must define an `update_stochastic` method. Later we can make the method definition optional perhaps but that requires some fairly unpleasant template magic.

We might consider updating this later to separate out logically the stochastic from the deterministic variables (perhaps making both available to read in both functions but only allowing the ode solver to change one set and the stochastic update to change the other). With this idea then the `update_stochastic_schedule()` method would error at runtime if used and there is no stochastic process added.

The bookkeeping around the next event needs tidying as it's doing a binary search on each call to `run()` - however, it's always correct this way so seems like a good place to start for now