### PR TITLE
Start adding suport for mode_info

### DIFF
--- a/inst/examples/logistic.cpp
+++ b/inst/examples/logistic.cpp
@@ -65,4 +65,9 @@ mode::pars_type<logistic> mode_pars<logistic>(cpp11::list pars) {
   return mode::pars_type<logistic>(shared);
 }
 
+template <>
+cpp11::sexp mode_info<logistic>(const mode::pars_type<logistic>& pars) {
+  return cpp11::writable::strings({"N1", "N2"});
+}
+
 }

--- a/inst/include/mode/mode.hpp
+++ b/inst/include/mode/mode.hpp
@@ -13,6 +13,11 @@ namespace mode {
 template <typename T>
 typename mode::pars_type<T> mode_pars(cpp11::list pars);
 
+template <typename T>
+cpp11::sexp mode_info(const mode::pars_type<T>& pars) {
+  return R_NilValue;
+}
+
 // TODO: consider a better name here, but using the same name as the
 // namespace does not end well...
 template <typename T>

--- a/inst/template/mode.R.template
+++ b/inst/template/mode.R.template
@@ -17,6 +17,7 @@
       res <- mode_{{name}}_alloc(pars, time, n_particles,
                                  n_threads, control, seed)
       private$ptr_ <- res[[1]]
+      private$info_ <- res[[2]]
       private$pars_ <- pars
       private$n_particles_ <- n_particles
       private$n_threads_ <- n_threads
@@ -32,6 +33,10 @@
 
     pars = function() {
       private$pars_
+    },
+
+    info = function() {
+      private$info_
     },
 
     time = function() {
@@ -89,9 +94,12 @@
     update_state = function(pars = NULL, time = NULL,
                             state = NULL, index = NULL,
                             set_initial_state = NULL, reset_step_size = NULL) {
-      mode_{{name}}_update_state(private$ptr_, pars, time, state, index,
+      info <- mode_{{name}}_update_state(private$ptr_, pars, time, state, index,
                                  set_initial_state, reset_step_size)
-      private$pars_ <- pars
+      if (!is.null(pars)) {
+        private$pars_ <- pars
+        private$info_ <- info
+      }
     },
 
     reorder = function(index) {

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -41,13 +41,13 @@ cpp11::sexp mode_{{name}}_stats(SEXP ptr) {
 }
 
 [[cpp11::register]]
-void mode_{{name}}_update_state(SEXP ptr,
-                                SEXP pars,
-                                SEXP time,
-                                SEXP state,
-                                SEXP index,
-                                SEXP set_initial_state,
-                                SEXP reset_step_size) {
+cpp11::sexp mode_{{name}}_update_state(SEXP ptr,
+                                       SEXP pars,
+                                       SEXP time,
+                                       SEXP state,
+                                       SEXP index,
+                                       SEXP set_initial_state,
+                                       SEXP reset_step_size) {
   return mode::r::mode_update_state<{{class}}>(ptr,
       pars, time, state, index, set_initial_state, reset_step_size);
 }

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -5,6 +5,7 @@ test_that("Can compile a simple model", {
   expect_s3_class(mod, "mode")
   expect_equal(mod$time(), pi)
   expect_equal(mod$pars(), ex$pars)
+  expect_equal(mod$info(), c("N1", "N2"))
   expect_equal(mod$n_particles(), n_particles)
   expected_control <- mode_control(max_steps = 10000, rtol = 1e-6, atol = 1e-6,
                           step_size_min = 1e-8, step_size_max = Inf)

--- a/tests/testthat/test-updating-state.R
+++ b/tests/testthat/test-updating-state.R
@@ -12,6 +12,8 @@ test_that("Can update time", {
   expect_equal(mod$time(), initial_time)
   res2 <- mod$run(5)
   expect_identical(res, res2)
+  ## Did not change pars on update
+  expect_identical(mod$pars(), pars)
 })
 
 test_that("Can only update time for all particles at once", {


### PR DESCRIPTION
This mirrors the same code in dust, and allows for models to return some arbitrary R object back derived from a set of parameters. Odin uses this to report back information about variable ordering and size. Having this in place will make sorting out the odin->mode compiler a bit easier