### PR TITLE
Change interface to match dust more closely

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mode
 Title: Solve Multiple ODEs
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = c("aut"),

--- a/inst/examples/logistic.cpp
+++ b/inst/examples/logistic.cpp
@@ -37,8 +37,8 @@ public:
   }
 
   void update_stochastic(double t, const std::vector<double>& y,
-                         std::vector<double> y_next,
-                         rng_state_type& rng_state) {
+                         rng_state_type& rng_state,
+                         std::vector<double>& y_next) {
   }
 
   size_t n_variables() const {

--- a/inst/examples/logistic.cpp
+++ b/inst/examples/logistic.cpp
@@ -36,7 +36,8 @@ public:
     return ret;
   }
 
-  void update_stochastic(double t, std::vector<double>& y,
+  void update_stochastic(double t, const std::vector<double>& y,
+                         std::vector<double> y_next,
                          rng_state_type& rng_state) {
   }
 

--- a/inst/examples/parallel.cpp
+++ b/inst/examples/parallel.cpp
@@ -51,8 +51,8 @@ public:
   }
 
   void update_stochastic(double t, const std::vector<double>& y,
-                         std::vector<double>& y_next,
-                         rng_state_type& rng_state) {
+                         rng_state_type& rng_state,
+                         std::vector<double>& y_next) {
   }
 
 private:

--- a/inst/examples/parallel.cpp
+++ b/inst/examples/parallel.cpp
@@ -50,7 +50,8 @@ public:
 #endif
   }
 
-  void update_stochastic(double t, std::vector<double>& y,
+  void update_stochastic(double t, const std::vector<double>& y,
+                         std::vector<double>& y_next,
                          rng_state_type& rng_state) {
   }
 

--- a/inst/examples/stochastic.cpp
+++ b/inst/examples/stochastic.cpp
@@ -36,10 +36,11 @@ public:
               std::vector<double>& output) {
   }
 
-  void update_stochastic(double t, std::vector<double>& y,
+  void update_stochastic(double t, const std::vector<double>& y,
+                         std::vector<double>& y_next,
                          rng_state_type& rng_state) {
     const double r = dust::random::normal<double>(rng_state, 0, shared->v);
-    y[2] *= std::exp(r);
+    y_next[2] = y[2] * std::exp(r);
   }
 
   std::vector<double> initial(double time) {

--- a/inst/examples/stochastic.cpp
+++ b/inst/examples/stochastic.cpp
@@ -37,8 +37,8 @@ public:
   }
 
   void update_stochastic(double t, const std::vector<double>& y,
-                         std::vector<double>& y_next,
-                         rng_state_type& rng_state) {
+                         rng_state_type& rng_state,
+                         std::vector<double>& y_next) {
     const double r = dust::random::normal<double>(rng_state, 0, shared->v);
     y_next[2] = y[2] * std::exp(r);
   }

--- a/inst/include/mode/solver.hpp
+++ b/inst/include/mode/solver.hpp
@@ -30,6 +30,7 @@ public:
          std::vector<double> y,
          control ctl) : t_(t),
                         ctl_(ctl),
+                        last_error_(0),
                         stepper_(m),
                         n_variables_(m.n_variables()),
                         n_output_(m.n_output()) {

--- a/inst/include/mode/stepper.hpp
+++ b/inst/include/mode/stepper.hpp
@@ -157,8 +157,9 @@ public:
   }
 
   void update_stochastic(double t, rng_state_type& rng_state) {
-    m.update_stochastic(t, y, y_next, rng_state);
-    std::copy_n(y_next.begin(), n_var, y.begin()); // y = y_next
+    std::copy_n(y.begin(), n_var, y_next.begin()); // y_next = y
+    m.update_stochastic(t, y, y_next, rng_state);  // update y -> y_next
+    std::swap(y, y_next);
     initialise(t); // must recalculate dydt at this point
   }
 

--- a/inst/include/mode/stepper.hpp
+++ b/inst/include/mode/stepper.hpp
@@ -157,7 +157,8 @@ public:
   }
 
   void update_stochastic(double t, rng_state_type& rng_state) {
-    m.update_stochastic(t, y, rng_state);
+    m.update_stochastic(t, y, y_next, rng_state);
+    std::copy_n(y_next.begin(), n_var, y.begin()); // y = y_next
     initialise(t); // must recalculate dydt at this point
   }
 

--- a/inst/include/mode/stepper.hpp
+++ b/inst/include/mode/stepper.hpp
@@ -153,6 +153,7 @@ public:
   }
 
   void initialise(double t) {
+    std::fill(k1.begin(), k1.end(), 0);
     m.rhs(t, y, k1);
   }
 

--- a/inst/include/mode/stepper.hpp
+++ b/inst/include/mode/stepper.hpp
@@ -158,7 +158,7 @@ public:
 
   void update_stochastic(double t, rng_state_type& rng_state) {
     std::copy_n(y.begin(), n_var, y_next.begin()); // y_next = y
-    m.update_stochastic(t, y, y_next, rng_state);  // update y -> y_next
+    m.update_stochastic(t, y, rng_state, y_next);  // update y -> y_next
     std::swap(y, y_next);
     initialise(t); // must recalculate dydt at this point
   }

--- a/inst/include/mode/stepper.hpp
+++ b/inst/include/mode/stepper.hpp
@@ -157,9 +157,13 @@ public:
   }
 
   void update_stochastic(double t, rng_state_type& rng_state) {
-    std::copy_n(y.begin(), n_var, y_next.begin()); // y_next = y
-    m.update_stochastic(t, y, rng_state, y_next);  // update y -> y_next
-    std::swap(y, y_next);
+    // Slightly odd construction here - we copy y into y_next so that
+    // they both hold the same values, then do the step to update from
+    // y_next to y so that at the end of this step 'y' holds the
+    // current values (and then the derivative calculation in
+    // initialise works as expected).
+    std::copy_n(y.begin(), n_var, y_next.begin()); // from y to y_next
+    m.update_stochastic(t, y_next, rng_state, y);  // from y_next to y
     initialise(t); // must recalculate dydt at this point
   }
 


### PR DESCRIPTION
A small interface change here, but I think one that we'll need to support odin generating the code for the stochastic updates as we pretty strongly assume that we'll always have two states (current and next - not sure why I set it up this way in #19!). This will require a small change to https://github.com/mrc-ide/odin.dust/pull/102/ to update the signature of the `update_stochastic` method

Was opened as #23 but with the wrong branch name :man_facepalming: 