### PR TITLE
Fix incorrect solution after reorder

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mode
 Title: Solve Multiple ODEs
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = c("aut"),

--- a/inst/include/mode/stepper.hpp
+++ b/inst/include/mode/stepper.hpp
@@ -134,18 +134,22 @@ public:
     }
   }
 
-  // store future y values in k3, future dydt in k2
-  // these will then be swapped into place (see "swap" below)
+  // store future y values in y_next, future dydt in k2 these will
+  // then be swapped into place (see "swap" below). It's important to
+  // move the y values into y_next and not one of the k* vectors that
+  // hold derivatives in case the model is stochastic and does not
+  // explicitly set a derivative for an equation (in which case they
+  // should be zero).
   void set_state(const stepper<Model>& other) {
     std::copy(other.k1.begin(), other.k1.end(), k2.begin());
-    std::copy(other.y.begin(), other.y.end(), k3.begin());
+    std::copy(other.y.begin(), other.y.end(), y_next.begin());
   }
 
   // to be called after "set_state(other)", see above
   // to populate desired y, k1 values
   void swap() {
     std::swap(k1, k2);
-    std::swap(y, k3);
+    std::swap(y, y_next);
   }
 
   void set_model(Model new_model) {

--- a/tests/testthat/test-dopri.R
+++ b/tests/testthat/test-dopri.R
@@ -19,3 +19,30 @@ test_that("can integrate logistic", {
   expect_equal(actual[1:2, 1, ], dde, tolerance = 1e-7)
   expect_identical(actual, actual[, rep(1, 5), ])
 })
+
+
+test_that("Can cope with systems that do not set all derivatives", {
+  path <- mode_file("examples/stochastic.cpp")
+  code <- readLines(path)
+  i <- grep("dydt\\[.+\\] = 0;", code)
+  stopifnot(length(i) == 1)
+  tmp <- tempfile(fileext = ".cpp")
+  writeLines(code[-i], tmp)
+  gen <- mode(tmp, quiet = TRUE)
+
+  pars <- list(r1 = 0.1, r2 = 0.2, K1 = 100, K2 = 100, v = 1)
+  mod1 <- gen$new(pars, 0, 1)
+  y1 <- vector("list", 3)
+  for (i in seq_along(y1)) {
+    y1[[i]] <- mod1$run(i)
+  }
+
+  mod2 <- gen$new(pars, 0, 1)
+  y2 <- vector("list", 3)
+  for (i in seq_along(y1)) {
+    mod2$reorder(1)
+    y2[[i]] <- mod2$run(i)
+  }
+
+  expect_equal(y2, y1)
+})


### PR DESCRIPTION
This fixes the issue we have seen in https://github.com/mrc-ide/mcstate/pull/214 where the derivatives for the stochastic compartments were changing unexpectedly. Because we were using `k3` as storage for the `y` values that copied a nonzero value over into a vector used in the stepper that was never zero'd. Using `y_next`, which holds values rather than derivatives, instead solves this. The test case added fails with the version of mode on main