### PR TITLE
Track steps taken by each particle, optionally

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mode
 Title: Solve Multiple ODEs
-Version: 0.1.4
+Version: 0.1.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = c("aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Solve multiple ODEs in parallel.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 URL: https://github.com/mrc-ide/mode
 BugReports: https://github.com/mrc-ide/mode/issues
 Imports:

--- a/R/interface.R
+++ b/R/interface.R
@@ -66,12 +66,18 @@ mode <- function(filename, quiet = FALSE, workdir = NULL, skip_cache = FALSE) {
 ##'   your rhs that the solver may skip over by accident, then specify
 ##'   a smaller maximum step size here.
 ##'
+##' @param debug_record_step_times Logical, indicating if we should record
+##'   the steps taken. This information will be available as part of
+##'   the `statistics()` output
+##'
 ##' @export
 ##' @return A named list of class "mode_control"
 mode_control <- function(max_steps = NULL, atol = NULL, rtol = NULL,
-                         step_size_min = NULL, step_size_max = NULL) {
+                         step_size_min = NULL, step_size_max = NULL,
+                         debug_record_step_times = NULL) {
   ctl <- list(max_steps = max_steps, atol = atol, rtol = rtol,
-              step_size_min = step_size_min, step_size_max = step_size_max)
+              step_size_min = step_size_min, step_size_max = step_size_max,
+              debug_record_step_times = debug_record_step_times)
   class(ctl) <- "mode_control"
   ctl
 }

--- a/inst/include/mode/control.hpp
+++ b/inst/include/mode/control.hpp
@@ -3,25 +3,26 @@ namespace mode {
 
 struct control {
   // TODO: I've had to un-const these for a bit
-  size_t max_steps;
-  double atol;
-  double rtol;
-  double step_size_min;
-  double step_size_max;
+  size_t max_steps = 10000;
+  double atol = 1e-6;
+  double rtol = 1e-8;
+  double step_size_min = 1e-8;
+  double step_size_max = std::numeric_limits<double>::infinity();
   double factor_safe = 0.9;
   double factor_min = 0.2;  // from dopri5.f:276, retard.f:328
   double factor_max = 10.0; // from dopri5.f:281, retard.f:333
   double beta = 0.04;
   double constant = 0.2 - 0.04 * 0.75; // 0.04 is beta
+  bool debug_record_step_times = false;
 
   control(size_t max_steps, double atol, double rtol, double step_size_min,
-          double step_size_max) :
+          double step_size_max, bool debug_record_step_times) :
       max_steps(max_steps), atol(atol), rtol(rtol),
       step_size_min(step_size_min),
-      step_size_max(step_size_max) {}
+      step_size_max(step_size_max),
+      debug_record_step_times(debug_record_step_times) {}
 
-  control() : max_steps(10000), atol(1e-6), rtol(1e-6), step_size_min(1e-8),
-              step_size_max(std::numeric_limits<double>::infinity()) {}
+  control() {}
 };
 
 }

--- a/inst/include/mode/control.hpp
+++ b/inst/include/mode/control.hpp
@@ -5,7 +5,7 @@ struct control {
   // TODO: I've had to un-const these for a bit
   size_t max_steps = 10000;
   double atol = 1e-6;
-  double rtol = 1e-8;
+  double rtol = 1e-6;
   double step_size_min = 1e-8;
   double step_size_max = std::numeric_limits<double>::infinity();
   double factor_safe = 0.9;

--- a/inst/include/mode/mode.hpp
+++ b/inst/include/mode/mode.hpp
@@ -211,12 +211,24 @@ public:
 
   void statistics(std::vector<size_t> &all_stats) {
     auto it = all_stats.begin();
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static) num_threads(n_threads_)
-#endif
+    // this is hard to make parallel safe without doing
+    //
+    // solver_i[i].statistics(it + i * 3);
+    //
+    // which requires knowing that we always have three statistics
+    // (though we do rely on this in r/mode.hpp::mode_stats)
     for (size_t i = 0; i < n_particles_; ++i) {
       it = solver_[i].statistics(it);
     }
+  }
+
+  std::vector<std::vector<double>> debug_step_times() {
+    std::vector<std::vector<double>> ret(n_particles_);
+    // This could be in parallel safely
+    for (size_t i = 0; i < n_particles_; ++i) {
+      ret[i] = solver_[i].debug_step_times();
+    }
+    return ret;
   }
 
   void check_errors() {

--- a/inst/include/mode/r/helpers.hpp
+++ b/inst/include/mode/r/helpers.hpp
@@ -3,6 +3,7 @@
 #include <cpp11/list.hpp>
 #include <cpp11/integers.hpp>
 #include <cpp11/doubles.hpp>
+#include <cpp11/logicals.hpp>
 
 namespace mode {
 namespace r {
@@ -214,6 +215,19 @@ double validate_double(SEXP r_value, double default_value, const char * name) {
 }
 
 inline
+bool validate_logical(SEXP r_value, bool default_value, const char * name) {
+  bool final_value = default_value;
+  if (r_value == R_NilValue) {
+    return final_value;
+  }
+  cpp11::logicals values = cpp11::as_cpp<cpp11::logicals>(r_value);
+  if (values.size() != 1) {
+    cpp11::stop("Expected '%s' to be a scalar value", name);
+  }
+  return values[0];
+}
+
+inline
 mode::control validate_control(cpp11::sexp r_control) {
   if (r_control == R_NilValue) {
     return mode::control();
@@ -230,8 +244,10 @@ mode::control validate_control(cpp11::sexp r_control) {
         mode::r::validate_double(control[4],
                                  std::numeric_limits<double>::infinity(),
                                  "step_size_max");
+    auto debug_record_step_times =
+        mode::r::validate_logical(control[5], false, "debug_record_step_times");
     return mode::control(max_steps, atol, rtol, step_size_min,
-                         step_size_max);
+                         step_size_max, debug_record_step_times);
   }
 }
 
@@ -242,7 +258,8 @@ cpp11::sexp control(const mode::control ctl) {
                                     "atol"_nm = ctl.atol,
                                     "rtol"_nm = ctl.rtol,
                                     "step_size_min"_nm = ctl.step_size_min,
-                                    "step_size_max"_nm = ctl.step_size_max});
+                                    "step_size_max"_nm = ctl.step_size_max,
+                                    "debug_record_step_times"_nm = ctl.debug_record_step_times});
 
   ret.attr("class") = "mode_control";
   return ret;

--- a/inst/include/mode/solver.hpp
+++ b/inst/include/mode/solver.hpp
@@ -81,15 +81,16 @@ public:
       if (err <= 1) {
         success = true;
         stats_.n_steps_accepted++;
-
         stepper_.step_complete(t_, h);
-
         double fac = fac11 / std::pow(fac_old, ctl_.beta);
         fac = clamp(fac / ctl_.factor_safe,
                     facc2, facc1);
         const double h_new = h / fac;
 
         t_ += h;
+        if (ctl_.debug_record_step_times) {
+          stats_.step_times.push_back(t_);
+        }
         if (reject) {
           h_ = std::min(h_new, h);
         } else {
@@ -208,6 +209,10 @@ public:
     all_stats[1] = stats_.n_steps_accepted;
     all_stats[2] = stats_.n_steps_rejected;
     return all_stats + 3;
+  }
+
+  std::vector<double> debug_step_times() {
+    return stats_.step_times;
   }
 };
 }

--- a/inst/include/mode/stats.hpp
+++ b/inst/include/mode/stats.hpp
@@ -5,11 +5,13 @@ struct stats {
   size_t n_steps;
   size_t n_steps_accepted;
   size_t n_steps_rejected;
+  std::vector<double> step_times;
 
   void reset() {
     n_steps = 0;
     n_steps_accepted = 0;
     n_steps_rejected = 0;
+    step_times.resize(0);
   }
 };
 

--- a/man/mode_control.Rd
+++ b/man/mode_control.Rd
@@ -9,7 +9,8 @@ mode_control(
   atol = NULL,
   rtol = NULL,
   step_size_min = NULL,
-  step_size_max = NULL
+  step_size_max = NULL,
+  debug_record_step_times = NULL
 )
 }
 \arguments{
@@ -33,6 +34,10 @@ no maximum step size (Inf) so the solver can take as large a
 step as it wants to.  If you have short-lived fluctuations in
 your rhs that the solver may skip over by accident, then specify
 a smaller maximum step size here.}
+
+\item{debug_record_step_times}{Logical, indicating if we should record
+the steps taken. This information will be available as part of
+the \code{statistics()} output}
 }
 \value{
 A named list of class "mode_control"

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -8,7 +8,8 @@ test_that("Can compile a simple model", {
   expect_equal(mod$info(), c("N1", "N2"))
   expect_equal(mod$n_particles(), n_particles)
   expected_control <- mode_control(max_steps = 10000, rtol = 1e-6, atol = 1e-6,
-                          step_size_min = 1e-8, step_size_max = Inf)
+                                   step_size_min = 1e-8, step_size_max = Inf,
+                                   debug_record_step_times = FALSE)
   expect_equal(mod$control(), expected_control)
 })
 
@@ -16,7 +17,8 @@ test_that("Can compile a simple model with control", {
   ex <- example_logistic()
   n_particles <- 10
   control <- mode_control(max_steps = 10, rtol = 0.01, atol = 0.02,
-                          step_size_min = 0.1, step_size_max = 1)
+                          step_size_min = 0.1, step_size_max = 1,
+                          debug_record_step_times = FALSE)
   mod <- ex$generator$new(ex$pars, pi, n_particles, control = control)
   ctl <- mod$control()
   expect_s3_class(control, "mode_control")


### PR DESCRIPTION
This PR tracks the number of steps taken by each particle. I assume this will carry some overhead so have put it behind a new control parameter.

There's a question about what to do on reorder - currently we do the same thing as the state and reorder statistics along with the state, but that leads to fairly uninterpretable results at the end of a particle filter. OTOH if we don't shuffle the stats, then the max_steps gets hard to think about. Something to discuss, but probably in addition to this PR?