### PR TITLE
Require that n_particles is positive

### DIFF
--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -27,6 +27,7 @@ cpp11::list mode_alloc(cpp11::list r_pars, double time, size_t n_particles,
   auto ctl = mode::r::validate_control(control);
   cpp11::sexp info = mode_info(pars);
   mode::r::validate_positive(n_threads, "n_threads");
+  mode::r::validate_positive(n_particles, "n_particles");
   container<T> *d = new mode::container<T>(pars, time, n_particles,
                                            n_threads, ctl, seed);
   cpp11::external_pointer<container<T>> ptr(d, true, false);

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -79,6 +79,14 @@ test_that("Can get arbitrary partial state", {
   expect_identical(state, res)
 })
 
+test_that("Error if initialised with no particles", {
+  ex <- example_logistic()
+  n_particles <- 10
+  expect_error(ex$generator$new(ex$pars, 0, 0),
+               "'n_particles' must be positive (was given 0)",
+               fixed = TRUE)
+})
+
 test_that("Error if partial state index is invalid", {
   ex <- example_logistic()
   n_particles <- 10


### PR DESCRIPTION
Fixes small validation issue - we rely on this property to avoid crashes because we look into the first particle for things like the stat size and time