### PR TITLE
Use single place to store control defaults

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mode
 Title: Solve Multiple ODEs
-Version: 0.1.6
+Version: 0.1.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = c("aut"),

--- a/inst/include/mode/r/helpers.hpp
+++ b/inst/include/mode/r/helpers.hpp
@@ -236,23 +236,31 @@ bool validate_logical(SEXP r_value, bool default_value, const char * name) {
 
 inline
 mode::control validate_control(cpp11::sexp r_control) {
+  const auto defaults = mode::control();
   if (r_control == R_NilValue) {
-    return mode::control();
+    return defaults;
   }
   else {
     auto control = cpp11::as_cpp<cpp11::list>(r_control);
-    auto max_steps = mode::r::validate_int(control[0], 1000, "max_steps");
-    auto atol = mode::r::validate_double(control[1], 1e-6, "atol");
-    auto rtol = mode::r::validate_double(control[2], 1e-6, "rtol");
-    auto step_size_min = mode::r::validate_double(control[3],
-                                                  1e-8,
+    auto max_steps = mode::r::validate_int(control["max_steps"],
+                                           defaults.max_steps,
+                                           "max_steps");
+    auto atol = mode::r::validate_double(control["atol"],
+                                         defaults.atol,
+                                         "atol");
+    auto rtol = mode::r::validate_double(control["rtol"],
+                                         defaults.rtol,
+                                         "rtol");
+    auto step_size_min = mode::r::validate_double(control["step_size_min"],
+                                                  defaults.step_size_min,
                                                   "step_size_min");
-    auto step_size_max =
-        mode::r::validate_double(control[4],
-                                 std::numeric_limits<double>::infinity(),
-                                 "step_size_max");
+    auto step_size_max = mode::r::validate_double(control["step_size_max"],
+                                                  defaults.step_size_max,
+                                                  "step_size_max");
     auto debug_record_step_times =
-        mode::r::validate_logical(control[5], false, "debug_record_step_times");
+        mode::r::validate_logical(control["debug_record_step_times"],
+                                  defaults.debug_record_step_times,
+                                  "debug_record_step_times");
     return mode::control(max_steps, atol, rtol, step_size_min,
                          step_size_max, debug_record_step_times);
   }

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -28,17 +28,28 @@ test_that("Can compile a simple model with control", {
 
 test_that("Can compile a simple model with partial control", {
   ex <- example_logistic()
-  n_particles <- 10
+  generate_control <- function(control) {
+    ex$generator$new(ex$pars, pi, 10, control = control)$control()
+  }
+
   control <- mode_control(max_steps = 10, atol = 0.2)
-  mod <- ex$generator$new(ex$pars, pi, n_particles, control = control)
-  expect_s3_class(control, "mode_control")
-  ctl <- mod$control()
+  ctl <- generate_control(control)
   expect_s3_class(ctl, "mode_control")
   expect_equal(ctl$max_steps, 10)
   expect_equal(ctl$atol, 0.2)
   expect_equal(ctl$rtol, 1e-6)
   expect_equal(ctl$step_size_min, 1e-8)
   expect_equal(ctl$step_size_max, Inf)
+  expect_false(ctl$debug_record_step_times)
+
+  default <- generate_control(NULL)
+  expect_equal(ctl, modifyList(default, list(max_steps = 10, atol = 0.2)))
+
+  ## A couple more
+  expect_equal(f(mode_control(atol = 0.2)),
+               modifyList(default, list(atol = 0.2)))
+  expect_equal(f(mode_control(debug_record_step_times = FALSE)),
+               modifyList(default, list(debug_record_step_times = FALSE)))
 })
 
 test_that("Returns full state from run when no index set", {

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -46,9 +46,9 @@ test_that("Can compile a simple model with partial control", {
   expect_equal(ctl, modifyList(default, list(max_steps = 10, atol = 0.2)))
 
   ## A couple more
-  expect_equal(f(mode_control(atol = 0.2)),
+  expect_equal(generate_control(mode_control(atol = 0.2)),
                modifyList(default, list(atol = 0.2)))
-  expect_equal(f(mode_control(debug_record_step_times = FALSE)),
+  expect_equal(generate_control(mode_control(debug_record_step_times = FALSE)),
                modifyList(default, list(debug_record_step_times = FALSE)))
 })
 


### PR DESCRIPTION
Fixes a small bug I noticed when looking at setting up pmcmc with mode:

```
path <- system.file("examples/logistic.cpp", package = "mode")
gen <- mode::mode(path)
pars <- list(r1 = 0.1, r2 = 0.2, K1 = 100, K2 = 100)
gen$new(pars, 0, 1)$control()$max_steps # 10000
gen$new(pars, 0, 1, control = mode::mode_control(atol = 1e-5))$control()$max_steps # 1000
```

This is because the default is set in two place - the helpers and the struct. This moves the only place where defaults are specified to be the struct.