### PR TITLE
Add version check

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -1,0 +1,146 @@
+on:
+  push:
+    branches:
+      - master
+      - main
+
+name: make-release
+
+jobs:
+  build-binaries:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macOS-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          # - {os: macOS-latest,   r: 'oldrel'}
+          - {os: windows-latest, r: 'oldrel'}
+
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@master
+        with:
+          r-version: ${{ matrix.config.r }}
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes"))
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("pkgbuild")
+          remotes::install_cran("covr")
+        shell: Rscript {0}
+
+      # Properly, should build source first!
+      - name: Build binary
+        shell: Rscript {0}
+        run: |
+          src <- pkgbuild::build(".", dest_path = tempdir())
+          bin <- pkgbuild::build(".", dest_path = tempdir(), binary = TRUE)
+          dir.create("build")
+          file.copy(c(src, bin), "build")
+
+      - name: Upload package
+        if: success()
+        uses: actions/upload-artifact@v2
+        with:
+          name: pkg-${{ matrix.config.os }}-${{ matrix.config.r }}
+          path: build
+
+  create-release:
+    runs-on: ubuntu-20.04
+
+    needs: build-binaries
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Extract version
+        run: |
+          echo "PACKAGE_VERSION=$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')" >> $GITHUB_ENV
+          echo "PACKAGE_NAME=$(grep '^Package' DESCRIPTION  | sed 's/.*: *//')" >> $GITHUB_ENV
+
+      - uses: actions/download-artifact@v2
+        with:
+          path: pkg
+
+      - name: Show directory
+        shell: bash
+        run: |
+          ls -R
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ env.PACKAGE_VERSION }}
+          release_name: Release ${{ env.PACKAGE_NAME }} ${{ env.PACKAGE_VERSION }}
+          draft: false
+          prerelease: false
+
+      - name: Upload source
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: pkg/pkg-macOS-latest-release/${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tgz
+          asset_name: ${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tgz
+          asset_content_type: application/gzip
+
+      - name: Upload macOS binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: pkg/pkg-macOS-latest-release/${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tar.gz
+          asset_name: ${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload Windows binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: pkg/pkg-windows-latest-release/${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.zip
+          asset_name: ${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload Windows binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: pkg/pkg-windows-latest-oldrel/${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}.zip
+          asset_name: ${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}_oldrel.zip
+          asset_content_type: application/zip

--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -1,0 +1,24 @@
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+
+name: Version Check
+
+jobs:
+  all:
+    runs-on: ubuntu-20.04
+
+    name: Version Check
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Check version format and availability
+        run: ./scripts/version_check

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mode
 Title: Solve Multiple ODEs
-Version: 0.1.6
+Version: 0.1.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = c("aut"),

--- a/scripts/version_check
+++ b/scripts/version_check
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -e
+# Usage:
+#   check_version [<version>]
+#
+# If version is not given as a positional argument, then we'll read it
+# from the DESCRIPTION file.
+#
+# We assume that a version already exists as a tag.
+VERSION=${1:-$(grep '^Version' DESCRIPTION  | sed 's/.*: *//')}
+TAG="v${VERSION}"
+
+echo "Proposed version number '$VERSION'"
+
+if echo "$VERSION" | grep -Eq "[0-9]+[.][0-9]+[.][0-9]+"; then
+    echo "[OK] Version number in correct format"
+else
+    echo "[ERROR] Invalid format version number '$VERSION' must be in format 'x.y.z'"
+    exit 1
+fi
+
+EXIT_CODE=0
+
+echo "Updating remote git data"
+git fetch --quiet
+
+BRANCH_DEFAULT=$(git remote show origin | awk '/HEAD branch/ {print $NF}')
+LAST_TAG=$(git describe --tags --abbrev=0 "origin/${BRANCH_DEFAULT}")
+
+echo "Last tag was $LAST_TAG"
+
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+    echo "[ERROR] Tag $TAG already exists - update version number"
+    exit 1
+else
+    echo "[OK] Version number not yet present as git tag"
+fi
+
+MAJOR=$(echo $VERSION | cut -d. -f1)
+MINOR=$(echo $VERSION | cut -d. -f2)
+PATCH=$(echo $VERSION | cut -d. -f3)
+
+LAST_VERSION=$(echo "$LAST_TAG" | sed 's/^v//')
+LAST_MAJOR=$(echo $LAST_VERSION | cut -d. -f1)
+LAST_MINOR=$(echo $LAST_VERSION | cut -d. -f2)
+LAST_PATCH=$(echo $LAST_VERSION | cut -d. -f3)
+
+if (( $MAJOR > $LAST_MAJOR )); then
+    echo "[OK] Increasing MAJOR version"
+    exit $EXIT_CODE
+elif (( $MINOR > $LAST_MINOR )); then
+    echo "[OK] Increasing MINOR version"
+    exit $EXIT_CODE
+elif (( $PATCH > $LAST_PATCH )); then
+    echo "[OK] Increasing PATCH version"
+    exit $EXIT_CODE
+else
+    echo "[ERROR] Version number has not increased relative to $LAST_VERSION"
+    exit 1
+fi


### PR DESCRIPTION
Adds two new github actions

* make-release will run after merge to main and build binaries (helpful once we need them) and tag a branch with the version number
* version-check will run on PR to main and check that the version number is not yet used

Most of the logic is in scripts/version_check, which is copied over from dust. Similar scripts exist in sircovid and spimalot

There's a race condition in this approach in that we compare the released versions by presence of tag, not by looking at the copy of DESCRIPTION on main, which means that there's ~10 minutes where the version does not exist. This can lead to make-release failing if there are quick successive merges, but then we find out that there's an issue at least.

See the build for c5ff3fe for a failed check