### PR TITLE
Harmonise argument order with dust

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mode
 Title: Solve Multiple ODEs
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = c("aut"),

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -201,10 +201,9 @@ cpp11::sexp mode_stats(SEXP ptr) {
 }
 
 template <typename T>
-cpp11::sexp mode_update_state(SEXP ptr, SEXP r_pars, SEXP r_time, SEXP r_state,
-                              SEXP r_index,
+cpp11::sexp mode_update_state(SEXP ptr, SEXP r_pars, SEXP r_state, SEXP r_time,
                               SEXP r_set_initial_state,
-                              SEXP r_reset_step_size) {
+                              SEXP r_index, SEXP r_reset_step_size) {
   mode::container<T> *obj =
       cpp11::as_cpp < cpp11::external_pointer<mode::container<T>>>(ptr).get();
 
@@ -240,6 +239,11 @@ cpp11::sexp mode_update_state(SEXP ptr, SEXP r_pars, SEXP r_time, SEXP r_state,
     obj->set_pars(pars);
     ret = mode_info<T>(pars);
   }
+  // NOTE: there's no equivalent to this in dust, with all the work
+  // done at the 'r/' level, so we don't try and preserve much about
+  // the order of variables here (partly because everywhere else
+  // within the ode work we do (time, state) not (state, time) as on
+  // entry here.
   obj->update_state(time, state, index, set_initial_state, reset_step_size);
   return ret;
 }

--- a/inst/template/mode.R.template
+++ b/inst/template/mode.R.template
@@ -107,15 +107,16 @@
       invisible(prev)
     },
 
-    update_state = function(pars = NULL, time = NULL,
-                            state = NULL, index = NULL,
-                            set_initial_state = NULL, reset_step_size = NULL) {
-      info <- mode_{{name}}_update_state(private$ptr_, pars, time, state, index,
-                                 set_initial_state, reset_step_size)
+    update_state = function(pars = NULL, state = NULL, time = NULL,
+                            set_initial_state = NULL, index = NULL,
+                            reset_step_size = NULL) {
+      info <- mode_{{name}}_update_state(private$ptr_, pars, state, time,
+                               set_initial_state, index, reset_step_size)
       if (!is.null(pars)) {
         private$pars_ <- pars
         private$info_ <- info
       }
+      invisible()
     },
 
     reorder = function(index) {

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -59,13 +59,13 @@ cpp11::sexp mode_{{name}}_stats(SEXP ptr) {
 [[cpp11::register]]
 cpp11::sexp mode_{{name}}_update_state(SEXP ptr,
                                        SEXP pars,
-                                       SEXP time,
                                        SEXP state,
-                                       SEXP index,
+                                       SEXP time,
                                        SEXP set_initial_state,
+                                       SEXP index,
                                        SEXP reset_step_size) {
   return mode::r::mode_update_state<{{class}}>(ptr,
-      pars, time, state, index, set_initial_state, reset_step_size);
+      pars, state, time, set_initial_state, index, reset_step_size);
 }
 
 [[cpp11::register]]


### PR DESCRIPTION
One of a bunch of jobs that need doing to smooth over the eventual merge into dust. No functionality changed, and should be invisible to most users as this method is always called with the arguments fully named