### PR TITLE
mrc-3823: mode/dust method harmonisation pt 1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mode
 Title: Solve Multiple ODEs
-Version: 0.1.11
+Version: 0.1.12
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = c("aut"),

--- a/inst/include/mode/mode.hpp
+++ b/inst/include/mode/mode.hpp
@@ -93,13 +93,13 @@ public:
     return solver_[0].time();
   }
 
-  void run(double end_time) {
+  void run(double time_end) {
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) num_threads(n_threads_)
 #endif
     for (size_t i = 0; i < n_particles_; ++i) {
       try {
-        solver_[i].solve(end_time, rng_.state(i));
+        solver_[i].solve(time_end, rng_.state(i));
       } catch (std::exception const& e) {
         errors_.capture(e, i);
       }
@@ -107,8 +107,8 @@ public:
     errors_.report();
   }
 
-  std::vector<double> simulate(const std::vector<double>& end_time) {
-    const size_t n_time = end_time.size();
+  std::vector<double> simulate(const std::vector<double>& time_end) {
+    const size_t n_time = time_end.size();
     const size_t n_state = n_state_run();
     std::vector<double> ret(n_particles() * n_state * n_time);
 
@@ -118,7 +118,7 @@ public:
     for (size_t i = 0; i < n_particles(); ++i) {
       try {
         for (size_t t = 0; t < n_time; ++t) {
-          solver_[i].solve(end_time[t], rng_.state(i));
+          solver_[i].solve(time_end[t], rng_.state(i));
           size_t offset = t * n_state * n_particles() + i * n_state;
           solver_[i].state(index_, ret.begin() + offset);
         }

--- a/inst/include/mode/r/helpers.hpp
+++ b/inst/include/mode/r/helpers.hpp
@@ -269,7 +269,7 @@ bool validate_logical(SEXP r_value, bool default_value, const char * name) {
 }
 
 inline
-mode::control validate_control(cpp11::sexp r_control) {
+mode::control validate_ode_control(cpp11::sexp r_control) {
   const auto defaults = mode::control();
   if (r_control == R_NilValue) {
     return defaults;

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -19,19 +19,29 @@ namespace mode {
 namespace r {
 
 template <typename T>
-cpp11::list mode_alloc(cpp11::list r_pars, double time, size_t n_particles,
-                       size_t n_threads,
-                       cpp11::sexp control, cpp11::sexp r_seed) {
+cpp11::list mode_alloc(cpp11::list r_pars, bool pars_multi, double time,
+                       cpp11::sexp r_n_particles, size_t n_threads,
+                       cpp11::sexp r_seed, bool deterministic,
+                       cpp11::sexp r_gpu_config, cpp11::sexp r_ode_control) {
+  if (deterministic) {
+    cpp11::stop("Deterministic mode not supported for model models");
+  }
+  if (r_gpu_config != R_NilValue) {
+    cpp11::stop("GPU support not enabled for this object");
+  }
   auto pars = mode::mode_pars<T>(r_pars);
   auto seed = dust::random::r::as_rng_seed<typename T::rng_state_type>(r_seed);
-  auto ctl = mode::r::validate_control(control);
+  auto ctl = mode::r::validate_ode_control(r_ode_control);
   cpp11::sexp info = mode_info(pars);
   mode::r::validate_positive(n_threads, "n_threads");
+  auto n_particles = cpp11::as_cpp<int>(r_n_particles);
   mode::r::validate_positive(n_particles, "n_particles");
   container<T> *d = new mode::container<T>(pars, time, n_particles,
                                            n_threads, ctl, seed);
   cpp11::external_pointer<container<T>> ptr(d, true, false);
-  return cpp11::writable::list({ptr, info});
+  cpp11::writable::integers r_shape({n_particles});
+  auto r_ctl = mode::r::control(ctl);
+  return cpp11::writable::list({ptr, info, r_shape, r_gpu_config, r_ctl});
 }
 
 template <typename T>
@@ -39,13 +49,6 @@ void mode_set_n_threads(SEXP ptr, size_t n_threads) {
   T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
   mode::r::validate_positive(n_threads, "n_threads");
   obj->set_n_threads(n_threads);
-}
-
-template <typename T>
-cpp11::sexp mode_control(SEXP ptr) {
-  T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
-  auto ctl = obj->ctl();
-  return mode::r::control(ctl);
 }
 
 template <typename T>
@@ -249,15 +252,9 @@ cpp11::sexp mode_update_state(SEXP ptr, SEXP r_pars, SEXP r_state, SEXP r_time,
 }
 
 template <typename T>
-size_t mode_n_state_full(SEXP ptr) {
+size_t mode_n_state(SEXP ptr) {
   T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
   return obj->n_state_full();
-}
-
-template <typename T>
-size_t mode_n_state_run(SEXP ptr) {
-  T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
-  return obj->n_state_run();
 }
 
 template <typename T>

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -24,7 +24,7 @@ cpp11::list mode_alloc(cpp11::list r_pars, bool pars_multi, double time,
                        cpp11::sexp r_seed, bool deterministic,
                        cpp11::sexp r_gpu_config, cpp11::sexp r_ode_control) {
   if (deterministic) {
-    cpp11::stop("Deterministic mode not supported for model models");
+    cpp11::stop("Deterministic mode not supported for mode models");
   }
   if (r_gpu_config != R_NilValue) {
     cpp11::stop("GPU support not enabled for this object");

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -125,14 +125,14 @@ void mode_set_stochastic_schedule(SEXP ptr, cpp11::sexp r_time) {
 }
 
 template <typename T>
-cpp11::sexp mode_run(SEXP ptr, double end_time) {
+cpp11::sexp mode_run(SEXP ptr, double time_end) {
   T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
   auto time = obj->time();
-  if (end_time < time) {
-    cpp11::stop("'end_time' (%f) must be greater than current time (%f)",
-                end_time, time);
+  if (time_end < time) {
+    cpp11::stop("'time_end' (%f) must be greater than current time (%f)",
+                time_end, time);
   }
-  obj->run(end_time);
+  obj->run(time_end);
 
   std::vector<double> dat(obj->n_state_run() * obj->n_particles());
   obj->state_run(dat);
@@ -140,25 +140,25 @@ cpp11::sexp mode_run(SEXP ptr, double end_time) {
 }
 
 template <typename T>
-cpp11::sexp mode_simulate(SEXP ptr, cpp11::sexp r_end_time) {
+cpp11::sexp mode_simulate(SEXP ptr, cpp11::sexp r_time_end) {
   T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
   obj->check_errors();
-  const auto end_time = as_vector_double(r_end_time, "end_time");
-  const auto n_time = end_time.size();
+  const auto time_end = as_vector_double(r_time_end, "time_end");
+  const auto n_time = time_end.size();
   if (n_time == 0) {
-    cpp11::stop("'end_time' must have at least one element");
+    cpp11::stop("'time_end' must have at least one element");
   }
-  if (end_time[0] < obj->time()) {
-    cpp11::stop("'end_time[1]' must be at least %f", obj->time());
+  if (time_end[0] < obj->time()) {
+    cpp11::stop("'time_end[1]' must be at least %f", obj->time());
   }
   for (size_t i = 1; i < n_time; ++i) {
-    if (end_time[i] < end_time[i - 1]) {
-      cpp11::stop("'end_time' must be non-decreasing (error on element %d)",
+    if (time_end[i] < time_end[i - 1]) {
+      cpp11::stop("'time_end' must be non-decreasing (error on element %d)",
                   i + 1);
     }
   }
 
-  auto dat = obj->simulate(end_time);
+  auto dat = obj->simulate(time_end);
 
   return mode::r::state_array(dat, obj->n_state_run(), obj->n_particles(),
                               n_time);

--- a/inst/template/mode.R.template
+++ b/inst/template/mode.R.template
@@ -97,14 +97,14 @@
       private$ode_control_
     },
 
-    run = function(end_time) {
-      m <- mode_{{name}}_run(private$ptr_, end_time)
+    run = function(time_end) {
+      m <- mode_{{name}}_run(private$ptr_, time_end)
       rownames(m) <- names(private$index_)
       m
     },
 
-    simulate = function(end_time) {
-      m <- mode_{{name}}_simulate(private$ptr_, end_time)
+    simulate = function(time_end) {
+      m <- mode_{{name}}_simulate(private$ptr_, time_end)
       rownames(m) <- names(private$index_)
       m
     },

--- a/inst/template/mode.R.template
+++ b/inst/template/mode.R.template
@@ -4,24 +4,41 @@
 
   private = list(
     pars_ = NULL,
-    info_ = NULL,
-    ptr_ = NULL,
-    n_particles_ = NULL,
-    n_threads_ = NULL,
+    pars_multi_ = NULL,
     index_ = NULL,
+    info_ = NULL,
+    n_threads_ = NULL,
+    n_particles_ = NULL,
+    n_particles_each_ = NULL,
+    shape_ = NULL,
+    gpu_config_ = NULL,
+    ode_control_ = NULL,
+    ptr_ = NULL,
     reload_ = {{reload}}
   ),
 
   public = list(
     initialize = function(pars, time, n_particles, n_threads = 1L,
-                          control = NULL, seed = NULL) {
-      res <- mode_{{name}}_alloc(pars, time, n_particles,
-                                 n_threads, control, seed)
-      private$ptr_ <- res[[1]]
-      private$info_ <- res[[2]]
+                          seed = NULL, pars_multi = FALSE,
+                          deterministic = FALSE, gpu_config = NULL,
+                          ode_control = NULL) {
+      res <- mode_{{name}}_alloc(pars, pars_multi, time, n_particles,
+                                 n_threads, seed, deterministic,
+                                 gpu_config, ode_control)
       private$pars_ <- pars
-      private$n_particles_ <- n_particles
+      private$pars_multi_ <- pars_multi
       private$n_threads_ <- n_threads
+      private$ptr_ <- res[[1L]]
+      private$info_ <- res[[2L]]
+      private$shape_ <- res[[3L]]
+      private$gpu_config_ <- res[[4L]]
+      private$ode_control_ <- res[[5L]]
+      private$n_particles_ <- prod(private$shape_)
+      if (pars_multi) {
+        private$n_particles_each_ <- private$n_particles_ / length(pars)
+      } else {
+        private$n_particles_each_ <- private$n_particles_
+      }
     },
 
     name = function() {
@@ -30,6 +47,14 @@
 
     n_particles = function() {
        private$n_particles_
+    },
+
+    n_particles_each = function() {
+       private$n_particles_each_
+    },
+
+    shape = function() {
+      private$shape_
     },
 
     pars = function() {
@@ -68,8 +93,8 @@
       private$index_
     },
 
-    control = function() {
-      mode_{{name}}_control(private$ptr_)
+    ode_control = function() {
+      private$ode_control_
     },
 
     run = function(end_time) {
@@ -84,16 +109,16 @@
       m
     },
 
-    statistics = function() {
+    ode_statistics = function() {
       mode_{{name}}_stats(private$ptr_)
     },
 
-    n_state_run = function() {
-      mode_{{name}}_n_state_run(private$ptr_)
+    n_state = function() {
+      mode_{{name}}_n_state(private$ptr_)
     },
 
-    n_state_full = function() {
-      mode_{{name}}_n_state_full(private$ptr_)
+    n_pars = function() {
+      if (private$pars_multi_) length(private$pars_) else 0L
     },
 
     n_threads = function() {
@@ -120,6 +145,7 @@
     },
 
     reorder = function(index) {
+      storage.mode(index) <- "integer"
       mode_{{name}}_reorder(private$ptr_, index)
       invisible()
     },
@@ -135,6 +161,5 @@
     has_openmp = function() {
       mode_{{name}}_has_openmp()
     }
-
   ))
 class({{name}}) <- c("mode_generator", class({{name}}))

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -29,13 +29,13 @@ cpp11::sexp mode_{{name}}_set_rng_state(SEXP ptr, cpp11::raws rng_state) {
 }
 
 [[cpp11::register]]
-cpp11::sexp mode_{{name}}_run(SEXP ptr, double end_time) {
-  return mode::r::mode_run<mode::container<{{class}}>>(ptr, end_time);
+cpp11::sexp mode_{{name}}_run(SEXP ptr, double time_end) {
+  return mode::r::mode_run<mode::container<{{class}}>>(ptr, time_end);
 }
 
 [[cpp11::register]]
-cpp11::sexp mode_{{name}}_simulate(SEXP ptr, cpp11::sexp end_time) {
-  return mode::r::mode_simulate<mode::container<{{class}}>>(ptr, end_time);
+cpp11::sexp mode_{{name}}_simulate(SEXP ptr, cpp11::sexp time_end) {
+  return mode::r::mode_simulate<mode::container<{{class}}>>(ptr, time_end);
 }
 
 [[cpp11::register]]

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -3,16 +3,13 @@
 {{model}}
 
 [[cpp11::register]]
-SEXP mode_{{name}}_alloc(cpp11::list r_pars, double time,
-                         size_t n_particles, size_t n_threads,
-                         cpp11::sexp control, cpp11::sexp seed) {
-  return mode::r::mode_alloc<{{class}}>(r_pars, time, n_particles, n_threads,
-      control, seed);
-}
-
-[[cpp11::register]]
-cpp11::sexp mode_{{name}}_control(SEXP ptr) {
-  return mode::r::mode_control<mode::container<{{class}}>>(ptr);
+SEXP mode_{{name}}_alloc(cpp11::list r_pars, bool pars_multi, double time,
+                         cpp11::sexp r_n_particles, size_t n_threads,
+                         cpp11::sexp r_seed, bool deterministic,
+                         cpp11::sexp r_gpu_config, cpp11::sexp r_ode_control) {
+  return mode::r::mode_alloc<{{class}}>(r_pars, pars_multi, time, r_n_particles,
+                                        n_threads, r_seed, deterministic,
+                                        r_gpu_config, r_ode_control);
 }
 
 [[cpp11::register]]
@@ -84,13 +81,8 @@ size_t mode_{{name}}_n_variables(SEXP ptr) {
 }
 
 [[cpp11::register]]
-size_t mode_{{name}}_n_state_run(SEXP ptr) {
-  return mode::r::mode_n_state_run<mode::container<{{class}}>>(ptr);
-}
-
-[[cpp11::register]]
-size_t mode_{{name}}_n_state_full(SEXP ptr) {
-  return mode::r::mode_n_state_full<mode::container<{{class}}>>(ptr);
+size_t mode_{{name}}_n_state(SEXP ptr) {
+  return mode::r::mode_n_state<mode::container<{{class}}>>(ptr);
 }
 
 [[cpp11::register]]

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -7,6 +7,9 @@ test_that("Can compile a simple model", {
   expect_equal(mod$pars(), ex$pars)
   expect_equal(mod$info(), c("N1", "N2"))
   expect_equal(mod$n_particles(), n_particles)
+  expect_equal(mod$shape(), n_particles)
+  expect_equal(mod$n_particles_each(), n_particles)
+  expect_equal(mod$n_pars(), 0L)
   expected_control <- mode_control(max_steps = 10000, rtol = 1e-6, atol = 1e-6,
                                    step_size_min = 1e-8, step_size_max = Inf,
                                    debug_record_step_times = FALSE)
@@ -97,6 +100,9 @@ test_that("Error if initialised with no particles", {
   n_particles <- 10
   expect_error(ex$generator$new(ex$pars, 0, 0),
                "'n_particles' must be positive (was given 0)",
+               fixed = TRUE)
+  expect_error(ex$generator$new(ex$pars, 0, -1),
+               "'n_particles' must be positive (was given -1)",
                fixed = TRUE)
 })
 
@@ -652,4 +658,20 @@ test_that("Can save a model and reload it after repair", {
 
   cmp <- gen$new(pars, 0, 1, seed = 1)$run(10)
   expect_equal(res, cmp)
+})
+
+
+test_that("prevent use of gpu", {
+  ex <- example_logistic()
+  expect_error(
+    ex$generator$new(ex$pars, 0, 1, gpu_config = 1),
+    "GPU support not enabled for this object")
+})
+
+
+test_that("prevent use of deterministic mode", {
+  ex <- example_logistic()
+  expect_error(
+    ex$generator$new(ex$pars, 0, 1, deterministic = TRUE),
+    "Deterministic mode not supported for model models")
 })

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -196,7 +196,7 @@ test_that("End time must be later than initial time", {
   initial_time <- 5
   mod <- ex$generator$new(ex$pars, initial_time, n_particles)
   expect_equal(mod$time(), initial_time)
-  e <- "'end_time' (2.000000) must be greater than current time (5.000000)"
+  e <- "'time_end' (2.000000) must be greater than current time (5.000000)"
   expect_error(mod$run(2), e, fixed = TRUE)
 })
 
@@ -619,16 +619,16 @@ test_that("check that simulate times are reasonable", {
 
   expect_error(
     mod$simulate(seq(-5, 5, 1)),
-    "'end_time[1]' must be at least 0", fixed = TRUE)
+    "'time_end[1]' must be at least 0", fixed = TRUE)
   expect_error(
     mod$simulate(numeric(0)),
-    "'end_time' must have at least one element", fixed = TRUE)
+    "'time_end' must have at least one element", fixed = TRUE)
   expect_error(
     mod$simulate(c(0, 1, 2, 3, 2, 5)),
-    "'end_time' must be non-decreasing (error on element 5)", fixed = TRUE)
+    "'time_end' must be non-decreasing (error on element 5)", fixed = TRUE)
   expect_error(
     mod$simulate(NULL),
-    "Expected a numeric vector for 'end_time'", fixed = TRUE)
+    "Expected a numeric vector for 'time_end'", fixed = TRUE)
 })
 
 

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -10,7 +10,7 @@ test_that("Can compile a simple model", {
   expected_control <- mode_control(max_steps = 10000, rtol = 1e-6, atol = 1e-6,
                                    step_size_min = 1e-8, step_size_max = Inf,
                                    debug_record_step_times = FALSE)
-  expect_equal(mod$control(), expected_control)
+  expect_equal(mod$ode_control(), expected_control)
 })
 
 test_that("Can compile a simple model with control", {
@@ -19,8 +19,8 @@ test_that("Can compile a simple model with control", {
   control <- mode_control(max_steps = 10, rtol = 0.01, atol = 0.02,
                           step_size_min = 0.1, step_size_max = 1,
                           debug_record_step_times = FALSE)
-  mod <- ex$generator$new(ex$pars, pi, n_particles, control = control)
-  ctl <- mod$control()
+  mod <- ex$generator$new(ex$pars, pi, n_particles, ode_control = control)
+  ctl <- mod$ode_control()
   expect_s3_class(control, "mode_control")
   expect_s3_class(ctl, "mode_control")
   expect_equal(ctl, control)
@@ -29,7 +29,7 @@ test_that("Can compile a simple model with control", {
 test_that("Can compile a simple model with partial control", {
   ex <- example_logistic()
   generate_control <- function(control) {
-    ex$generator$new(ex$pars, pi, 10, control = control)$control()
+    ex$generator$new(ex$pars, pi, 10, ode_control = control)$ode_control()
   }
 
   control <- mode_control(max_steps = 10, atol = 0.2)
@@ -223,14 +223,14 @@ test_that("Can retrieve statistics", {
   ex <- example_logistic()
   n_particles <- 5
   mod <- ex$generator$new(ex$pars, 1, n_particles)
-  stats <- mod$statistics()
+  stats <- mod$ode_statistics()
   expect_equal(dim(stats), c(3, n_particles))
   expect_equal(row.names(stats),
                c("n_steps", "n_steps_accepted", "n_steps_rejected"))
   expect_s3_class(stats, "mode_statistics")
   expect_true(all(stats == 0))
   lapply(1:10, function(t) mod$run(t))
-  stats <- mod$statistics()
+  stats <- mod$ode_statistics()
   expect_true(all(stats == stats[, rep(1, n_particles)]))
   expect_true(all(stats["n_steps", ] > 0))
 
@@ -241,14 +241,14 @@ test_that("Can retrieve statistics", {
   ex <- example_logistic()
   n_particles <- 5
   mod <- ex$generator$new(ex$pars, 1, n_particles)
-  stats <- mod$statistics()
+  stats <- mod$ode_statistics()
   expect_equal(dim(stats), c(3, n_particles))
   expect_equal(row.names(stats),
                c("n_steps", "n_steps_accepted", "n_steps_rejected"))
   expect_s3_class(stats, "mode_statistics")
   expect_true(all(stats == 0))
   lapply(1:10, function(t) mod$run(t))
-  stats <- mod$statistics()
+  stats <- mod$ode_statistics()
   expect_true(all(stats == stats[, rep(1, n_particles)]))
   expect_true(all(stats["n_steps", ] > 0))
 })
@@ -256,14 +256,11 @@ test_that("Can retrieve statistics", {
 test_that("Can get model size", {
   ex <- example_logistic()
   mod <- ex$generator$new(ex$pars, 1, 1)
-  expect_equal(mod$n_state_run(), 3)
-  expect_equal(mod$n_state_full(), 3)
+  expect_equal(mod$n_state(), 3)
   mod$set_index(1)
-  expect_equal(mod$n_state_run(), 1)
-  expect_equal(mod$n_state_full(), 3)
+  expect_equal(mod$n_state(), 3)
   mod$set_index(c(1, 2, 3))
-  expect_equal(mod$n_state_run(), 3)
-  expect_equal(mod$n_state_full(), 3)
+  expect_equal(mod$n_state(), 3)
 })
 
 test_that("can run to noninteger time", {
@@ -281,7 +278,8 @@ test_that("can run to noninteger time", {
 
 test_that("Errors are reported", {
   ex <- example_logistic()
-  mod <- ex$generator$new(ex$pars, 0, 2, control = mode_control(max_steps = 1))
+  mod <- ex$generator$new(ex$pars, 0, 2,
+                          ode_control = mode_control(max_steps = 1))
   err <- expect_error(mod$run(5), "2 particles reported errors.")
   expect_match(
     err$message,
@@ -510,8 +508,8 @@ test_that("Can get information about steps", {
   pars <- list(r1 = 0.1, r2 = 0.2, K1 = 100, K2 = 200, v = 0.5)
   n_particles <- 5L
   control <- mode_control(debug_record_step_times = TRUE)
-  mod <- gen$new(pars, 0L, n_particles, control = control, seed = 1L)
-  stats <- mod$statistics()
+  mod <- gen$new(pars, 0L, n_particles, ode_control = control, seed = 1L)
+  stats <- mod$ode_statistics()
   schedule <- seq(0, 5, length.out = 11)
   mod$set_stochastic_schedule(schedule)
 
@@ -527,7 +525,7 @@ test_that("Can get information about steps", {
 
   mod$run(10)
 
-  stats <- mod$statistics()
+  stats <- mod$ode_statistics()
   steps <- attr(stats, "step_times")
   expect_equal(lengths(steps), stats["n_steps_accepted", ])
   ## Only end points of the steps are included:
@@ -544,22 +542,22 @@ test_that("information about steps survives shuffle", {
   control <- mode_control(debug_record_step_times = TRUE)
 
   ## First, run through in one go:
-  mod <- gen$new(pars, 0L, n_particles, control = control, seed = 1L)
+  mod <- gen$new(pars, 0L, n_particles, ode_control = control, seed = 1L)
   schedule <- seq(0, 5, length.out = 11)
   mod$set_stochastic_schedule(schedule)
   y1 <- mod$run(10)
-  stats1 <- mod$statistics()
+  stats1 <- mod$ode_statistics()
   steps1 <- attr(stats1, "step_times")
 
   ## At reverse, things look ok
   reverse <- rev(seq_len(n_particles))
   mod$reorder(reverse)
   expect_equal(mod$state(), y1[, reverse])
-  expect_equal(mod$statistics()[, ], stats1[, reverse])
-  expect_equal(attr(mod$statistics(), "step_times"), steps1[reverse])
+  expect_equal(mod$ode_statistics()[, ], stats1[, reverse])
+  expect_equal(attr(mod$ode_statistics(), "step_times"), steps1[reverse])
 
   ## Then again, but shuffle at half time
-  mod <- gen$new(pars, 0L, n_particles, control = control, seed = 1L)
+  mod <- gen$new(pars, 0L, n_particles, ode_control = control, seed = 1L)
   schedule <- seq(0, 5, length.out = 11)
   mod$set_stochastic_schedule(schedule)
   mod$run(5) # must be part of the stochastic updates
@@ -567,12 +565,12 @@ test_that("information about steps survives shuffle", {
   ## Reverse the rng state too
   mod$set_rng_state(c(matrix(mod$rng_state(), ncol = n_particles)[, reverse]))
   y2 <- mod$run(10)
-  stats2 <- mod$statistics()
+  stats2 <- mod$ode_statistics()
   steps2 <- attr(stats2, "step_times")
 
   expect_equal(mod$state(), y1[, reverse])
-  expect_equal(mod$statistics()[, ], stats1[, reverse])
-  expect_equal(attr(mod$statistics(), "step_times"), steps1[reverse])
+  expect_equal(mod$ode_statistics()[, ], stats1[, reverse])
+  expect_equal(attr(mod$ode_statistics(), "step_times"), steps1[reverse])
 })
 
 

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -673,5 +673,5 @@ test_that("prevent use of deterministic mode", {
   ex <- example_logistic()
   expect_error(
     ex$generator$new(ex$pars, 0, 1, deterministic = TRUE),
-    "Deterministic mode not supported for model models")
+    "Deterministic mode not supported for mode models")
 })

--- a/tests/testthat/test-updating-state.R
+++ b/tests/testthat/test-updating-state.R
@@ -56,10 +56,10 @@ test_that("Updating time resets statistics", {
   initial_time <- 1
   mod <- gen$new(pars, initial_time, n_particles)
   res <- mod$run(5)
-  expect_false(all(mod$statistics() == 0))
+  expect_false(all(mod$ode_statistics() == 0))
 
   mod$update_state(time = initial_time)
-  expect_true(all(mod$statistics() == 0))
+  expect_true(all(mod$ode_statistics() == 0))
 })
 
 test_that("Updating time does not reset state if new state is provided", {
@@ -221,9 +221,9 @@ test_that("Updating state does not reset statistics", {
   n_particles <- 2
   mod <- gen$new(pars, 0, n_particles)
   res <- mod$run(2)
-  stats <- mod$statistics()
+  stats <- mod$ode_statistics()
   mod$update_state(state = c(2, 2))
-  expect_identical(stats, mod$statistics())
+  expect_identical(stats, mod$ode_statistics())
 })
 
 test_that("Nothing happens if any arguments are invalid", {
@@ -366,9 +366,9 @@ test_that("Can reorder particles", {
   mod_fresh$update_state(state = y)
   mod$run(100)
   mod_fresh$run(100)
-  stats <- mod$statistics()
+  stats <- mod$ode_statistics()
   expect_false(all(unclass(stats) == stats[, 5:1]))
-  expect_identical(stats[, 5:1], unclass(mod_fresh$statistics()))
+  expect_identical(stats[, 5:1], unclass(mod_fresh$ode_statistics()))
   expect_identical(mod$state()[, 5:1], mod_fresh$state())
 })
 
@@ -395,8 +395,8 @@ test_that("Can reorder particles with duplication", {
   mod_fresh$update_state(state = y)
   mod$run(100)
   mod_fresh$run(100)
-  stats <- mod$statistics()
-  stats_fresh <- mod_fresh$statistics()
+  stats <- mod$ode_statistics()
+  stats_fresh <- mod_fresh$ode_statistics()
   expect_false(all(unclass(stats_fresh) == stats_fresh[, order_index]))
   expect_identical(unclass(stats), stats_fresh[, order_index])
   expect_identical(mod$state(), mod_fresh$state()[, order_index])
@@ -415,16 +415,16 @@ test_that("Can reorder particles mid-flight", {
   mod$update_state(state = y0, time = initial_time)
   mod$run(5)
   y1 <- mod$run(10)
-  s1 <- mod$statistics()
+  s1 <- mod$ode_statistics()
 
   ## Run half way, reorder, continue:
   mod$update_state(state = y0, time = initial_time)
 
   y2 <- mod$run(5)
-  s2 <- mod$statistics()
+  s2 <- mod$ode_statistics()
   mod$reorder(5:1)
   y3 <- mod$run(10)
-  s3 <- mod$statistics()
+  s3 <- mod$ode_statistics()
 
   expect_identical(y3, y1[, 5:1])
   expect_true(all(unclass(s3) == s3[, 5:1]))


### PR DESCRIPTION
This is the first in a series of PRs that harmonise the mode interface with dust. The aim is to eventually be able to use dust's `inst/template/dust.R.template` file and corresponding .hpp/.cpp templates in mode, with the ODE specific differences beginning at the `inst/include/mode.hpp` or `inst/include/r/mode.hpp` file.

This PR does the basic differences:

* full set of args to initialize (there will be a PR to dust later to add ode_control); this adds `gpu_config` and `deterministic`, both of which error if used. The return type of the allocate method has changed, and that has obsoleted the control getter which means we don't need that in dust later.
* new simple methods `n_particles_each`, `n_pars` and `shape` all of which are only really meaningful with multiple parameter sets, but all of which are trivial
* disambiguate "control" for "ode_control" everywhere
* `time_end` becomes `end_time` (dust moved from `step_end` to `time_end`, somehow we also have an ordering difference here)
* the `n_state_run` method has disappeared - later we might put this back, but after the merge

The next couple of PRs to follow after this:

* dummy support for "data" methods (set data, compare state to data, run a particle filter, resample) - we'll error on use
* compile-time support for the "param" method, which describes input parameters
* "capabilities" support which generalises the openmp reporting to include information on things that the model can do (e.g., data comparison, gpu support, size of the real number in bits, and the rng algorithm used)