### PR TITLE
Add dust-style capabilities testing

### DIFF
--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -276,5 +276,26 @@ void mode_reorder(SEXP ptr, cpp11::sexp r_index) {
   obj->reorder(index);
 }
 
+template <typename T>
+cpp11::sexp mode_capabilities() {
+  using namespace cpp11::literals;
+#ifdef _OPENMP
+  bool openmp = true;
+#else
+  bool openmp = false;
+#endif
+  bool gpu = false;
+  bool compare = false;
+  using real_type = double; // typename T::real_type;
+  auto real_size = sizeof(real_type);
+  auto rng_algorithm =
+    dust::random::r::algorithm_name<typename T::rng_state_type>();
+  return cpp11::writable::list({"openmp"_nm = openmp,
+                                "compare"_nm = compare,
+                                "gpu"_nm = gpu,
+                                "rng_algorithm"_nm = rng_algorithm,
+                                "real_size"_nm = real_size * CHAR_BIT});
+}
+
 }
 }

--- a/inst/template/mode.R.template
+++ b/inst/template/mode.R.template
@@ -159,7 +159,27 @@
     },
 
     has_openmp = function() {
-      mode_{{name}}_has_openmp()
+      mode_{{name}}_capabilities()[["openmp"]]
+    },
+
+    has_gpu_support = function(fake_gpu = FALSE) {
+      if (fake_gpu) {
+        FALSE
+      } else {
+        mode_{{name}}_capabilities()[["gpu"]]
+      }
+    },
+
+    has_compare = function() {
+      mode_{{name}}_capabilities()[["compare"]]
+    },
+
+    real_size = function() {
+      mode_{{name}}_capabilities()[["real_size"]]
+    },
+
+    rng_algorithm = function() {
+      mode_{{name}}_capabilities()[["rng_algorithm"]]
     }
   ))
 class({{name}}) <- c("mode_generator", class({{name}}))

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -96,10 +96,6 @@ void mode_{{name}}_set_n_threads(SEXP ptr, int n_threads) {
 }
 
 [[cpp11::register]]
-bool mode_{{name}}_has_openmp() {
-#ifdef _OPENMP
-  return true;
-#else
-  return false;
-#endif
+cpp11::sexp mode_{{name}}_capabilities() {
+  return mode::r::mode_capabilities<{{class}}>();
 }

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -675,3 +675,15 @@ test_that("prevent use of deterministic mode", {
     ex$generator$new(ex$pars, 0, 1, deterministic = TRUE),
     "Deterministic mode not supported for mode models")
 })
+
+
+test_that("investigate model capabilities", {
+  ex <- example_logistic()
+  mod <- ex$generator$new(ex$pars, 0, 1)
+  expect_type(mod$has_openmp(), "logical")
+  expect_false(mod$has_gpu_support())
+  expect_false(mod$has_gpu_support(TRUE))
+  expect_false(mod$has_compare())
+  expect_equal(mod$real_size(), 64)
+  expect_equal(mod$rng_algorithm(), "xoshiro256plus")
+})


### PR DESCRIPTION
This PR generalises the openmp check that we already to do check for other things that we are interested in knowing with mode/dust models:

* whether or not we can run it on the GPU at all; here we can never do this
* if it has a compiled compare function, required to run a particle filter in compiled code; we do not support this
* how big the real (floating point size) is; here always 64 bit
* which rng algorithm is being used; here always "xoshro256plus"

Like #40, this PR primarily decreases the distance between the mode and dust templates