### PR TITLE
mrc-3825: Use dust approach to method provision on initialisation

### DIFF
--- a/R/interface.R
+++ b/R/interface.R
@@ -114,7 +114,7 @@ mode_template_data <- function(model, config, reload_data) {
        param = "NULL",
        cuda = NULL, # unused here, used in dust
        target = "ode",
-       container = "container", # TODO: Change this to dust_ode
+       container = "dust_ode",
        has_gpu_support = as.character(FALSE),
        methods_gpu = methods_gpu,
        methods_cpu = methods_cpu,

--- a/R/interface.R
+++ b/R/interface.R
@@ -90,6 +90,41 @@ compile_mode <- function(filename, config, workdir, quiet) {
 }
 
 
+mode_template_data <- function(model, config, reload_data) {
+  methods <- function(target) {
+    nms <- c("alloc", "run", "simulate", "set_index", "n_state",
+             "update_state", "state", "time", "reorder", "resample",
+             "rng_state", "set_rng_state", "set_n_threads",
+             "set_data", "compare_data", "filter", "set_stochastic_schedule",
+             "ode_statistics")
+    m <- sprintf("%s = mode_%s_%s", nms, config$name, nms)
+    sprintf("list(\n%s)",  paste("          ", m, collapse = ",\n"))
+  }
+  methods_cpu <- methods("cpu")
+  methods_gpu <- paste(
+    "list(alloc = function(...) {",
+    '          stop("GPU support not enabled for this object")',
+    "        })", sep = "\n")
+
+  reload <- paste(deparse(reload_data), collapse = "\n")
+
+  list(model = model,
+       name = config$name,
+       class = config$class,
+       param = "NULL",
+       # cuda = ignore,  # not used so not a problem
+       # target = "ode", # 2nd thing to change
+       # container = "dust_cpu" # this is the next thing to change
+       has_gpu_support = as.character(FALSE),
+       methods_gpu = methods_gpu,
+       methods_cpu = methods_cpu,
+       reload = reload,
+       ## Non package interface only
+       base = config$base,
+       path_mode_include = mode_file("include"))
+}
+
+
 generate_mode <- function(filename, config, workdir) {
   model <- read_lines(filename)
 
@@ -97,13 +132,8 @@ generate_mode <- function(filename, config, workdir) {
   ## its own thing.
   path <- mode_workdir(workdir)
   reload_data <- list(path = path, base = config$base)
-  reload <- paste(deparse(reload_data), collapse = "\n")
-  data <- list(model = model,
-               name = config$name,
-               class = config$class,
-               base = config$base,
-               reload = reload,
-               path_mode_include = mode_file("include"))
+
+  data <- mode_template_data(model, config, reload_data)
 
   dir.create(file.path(path, "R"), FALSE, TRUE)
   dir.create(file.path(path, "src"), FALSE, TRUE)

--- a/R/interface.R
+++ b/R/interface.R
@@ -112,9 +112,9 @@ mode_template_data <- function(model, config, reload_data) {
        name = config$name,
        class = config$class,
        param = "NULL",
-       # cuda = ignore,  # not used so not a problem
-       # target = "ode", # 2nd thing to change
-       # container = "dust_cpu" # this is the next thing to change
+       cuda = NULL, # unused here, used in dust
+       target = "ode",
+       container = "container", # TODO: Change this to dust_ode
        has_gpu_support = as.character(FALSE),
        methods_gpu = methods_gpu,
        methods_cpu = methods_cpu,

--- a/inst/include/mode/mode.hpp
+++ b/inst/include/mode/mode.hpp
@@ -21,16 +21,16 @@ cpp11::sexp mode_info(const mode::pars_type<T>& pars) {
 // TODO: consider a better name here, but using the same name as the
 // namespace does not end well...
 template <typename T>
-class container {
+class dust_ode {
 public:
   using model_type = T;
   using pars_type = mode::pars_type<T>;
   using rng_state_type = typename T::rng_state_type;
   using rng_int_type = typename rng_state_type::int_type;
 
-  container(const pars_type &pars, const double time,
-            const size_t n_particles, const size_t n_threads,
-            const control ctl, const std::vector<rng_int_type>& seed)
+  dust_ode(const pars_type &pars, const double time,
+           const size_t n_particles, const size_t n_threads,
+           const control ctl, const std::vector<rng_int_type>& seed)
       : n_particles_(n_particles),
         n_threads_(n_threads),
         m_(model_type(pars)),

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -33,9 +33,9 @@ cpp11::list mode_alloc(cpp11::list r_pars, bool pars_multi, double time,
   mode::r::validate_positive(n_threads, "n_threads");
   auto n_particles = cpp11::as_cpp<int>(r_n_particles);
   mode::r::validate_positive(n_particles, "n_particles");
-  container<T> *d = new mode::container<T>(pars, time, n_particles,
+  dust_ode<T> *d = new mode::dust_ode<T>(pars, time, n_particles,
                                            n_threads, ctl, seed);
-  cpp11::external_pointer<container<T>> ptr(d, true, false);
+  cpp11::external_pointer<dust_ode<T>> ptr(d, true, false);
   cpp11::writable::integers r_shape({n_particles});
   auto r_ctl = mode::r::control(ctl);
   return cpp11::writable::list({ptr, info, r_shape, r_gpu_config, r_ctl});
@@ -204,8 +204,8 @@ template <typename T>
 cpp11::sexp mode_update_state(SEXP ptr, SEXP r_pars, SEXP r_state, SEXP r_time,
                               SEXP r_set_initial_state,
                               SEXP r_index, SEXP r_reset_step_size) {
-  mode::container<T> *obj =
-      cpp11::as_cpp < cpp11::external_pointer<mode::container<T>>>(ptr).get();
+  mode::dust_ode<T> *obj =
+      cpp11::as_cpp < cpp11::external_pointer<mode::dust_ode<T>>>(ptr).get();
 
   std::vector<size_t> index;
   const size_t index_max = obj->n_variables();

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -26,9 +26,6 @@ cpp11::list mode_alloc(cpp11::list r_pars, bool pars_multi, double time,
   if (deterministic) {
     cpp11::stop("Deterministic mode not supported for mode models");
   }
-  if (r_gpu_config != R_NilValue) {
-    cpp11::stop("GPU support not enabled for this object");
-  }
   auto pars = mode::mode_pars<T>(r_pars);
   auto seed = dust::random::r::as_rng_seed<typename T::rng_state_type>(r_seed);
   auto ctl = mode::r::validate_ode_control(r_ode_control);

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -185,7 +185,7 @@ cpp11::sexp mode_state(SEXP ptr, SEXP r_index) {
 }
 
 template <typename T>
-cpp11::sexp mode_stats(SEXP ptr) {
+cpp11::sexp mode_ode_statistics(SEXP ptr) {
   T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
   const auto n_particles = obj->n_particles();
   std::vector<size_t> dat(3 * n_particles);

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -162,16 +162,14 @@ cpp11::sexp mode_simulate(SEXP ptr, cpp11::sexp r_time_end) {
 }
 
 template <typename T>
-cpp11::sexp mode_state_full(SEXP ptr) {
-  T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
+cpp11::sexp mode_state_full(T *obj) {
   std::vector<double> dat(obj->n_state_full() * obj->n_particles());
   obj->state_full(dat);
   return mode::r::state_array(dat, obj->n_state_full(), obj->n_particles());
 }
 
 template <typename T>
-cpp11::sexp mode_state(SEXP ptr, SEXP r_index) {
-  T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
+cpp11::sexp mode_state_select(T *obj, SEXP r_index) {
   const size_t index_max = obj->n_state_full();
   const std::vector <size_t> index =
       mode::r::r_index_to_index(r_index, index_max);
@@ -179,6 +177,16 @@ cpp11::sexp mode_state(SEXP ptr, SEXP r_index) {
   std::vector<double> dat(n * obj->n_particles());
   obj->state(dat, index);
   return mode::r::state_array(dat, n, obj->n_particles());
+}
+
+template <typename T>
+cpp11::sexp mode_state(SEXP ptr, SEXP r_index) {
+  T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
+  if (r_index == R_NilValue) {
+    return mode_state_full(obj);
+  } else {
+    return mode_state_select(obj, r_index);
+  }
 }
 
 template <typename T>

--- a/inst/template/mode.R.template
+++ b/inst/template/mode.R.template
@@ -14,6 +14,8 @@
     gpu_config_ = NULL,
     ode_control_ = NULL,
     ptr_ = NULL,
+    methods_ = NULL,
+    param_ = {{param}},
     reload_ = {{reload}}
   ),
 
@@ -22,9 +24,13 @@
                           seed = NULL, pars_multi = FALSE,
                           deterministic = FALSE, gpu_config = NULL,
                           ode_control = NULL) {
-      res <- mode_{{name}}_alloc(pars, pars_multi, time, n_particles,
-                                 n_threads, seed, deterministic,
-                                 gpu_config, ode_control)
+      if (is.null(gpu_config)) {
+        private$methods_ <- {{methods_cpu}}
+      } else {
+        private$methods_ <- {{methods_gpu}}
+      }
+      res <- private$methods_$alloc(pars, pars_multi, time, n_particles,
+                        n_threads, seed, deterministic, gpu_config, ode_control)
       private$pars_ <- pars
       private$pars_multi_ <- pars_multi
       private$n_threads_ <- n_threads
@@ -43,6 +49,10 @@
 
     name = function() {
       "{{name}}"
+    },
+
+    param = function() {
+      private$param_
     },
 
     n_particles = function() {
@@ -66,26 +76,26 @@
     },
 
     rng_state = function(first_only = FALSE, last_only = FALSE) {
-      mode_{{name}}_rng_state(private$ptr_, first_only, last_only)
+      private$methods_$rng_state(private$ptr_, first_only, last_only)
     },
 
     set_rng_state = function(rng_state) {
-      mode_{{name}}_set_rng_state(private$ptr_, rng_state)
+      private$methods_$set_rng_state(private$ptr_, rng_state)
       invisible()
     },
 
     time = function() {
-      mode_{{name}}_time(private$ptr_)
+      private$methods_$time(private$ptr_)
     },
 
     set_index = function(index) {
-      mode_{{name}}_set_index(private$ptr_, index)
+      private$methods_$set_index(private$ptr_, index)
       private$index_ <- index
       invisible()
     },
 
     set_stochastic_schedule = function(time) {
-      mode_{{name}}_set_stochastic_schedule(private$ptr_, time)
+      private$methods_$set_stochastic_schedule(private$ptr_, time)
       invisible()
     },
 
@@ -98,23 +108,23 @@
     },
 
     run = function(time_end) {
-      m <- mode_{{name}}_run(private$ptr_, time_end)
+      m <- private$methods_$run(private$ptr_, time_end)
       rownames(m) <- names(private$index_)
       m
     },
 
     simulate = function(time_end) {
-      m <- mode_{{name}}_simulate(private$ptr_, time_end)
+      m <- private$methods_$simulate(private$ptr_, time_end)
       rownames(m) <- names(private$index_)
       m
     },
 
     ode_statistics = function() {
-      mode_{{name}}_stats(private$ptr_)
+      private$methods_$stats(private$ptr_)
     },
 
     n_state = function() {
-      mode_{{name}}_n_state(private$ptr_)
+      private$methods_$n_state(private$ptr_)
     },
 
     n_pars = function() {
@@ -127,7 +137,7 @@
 
     set_n_threads = function(n_threads) {
       prev <- private$n_threads_
-      mode_{{name}}_set_n_threads(private$ptr_, n_threads)
+      private$methods_$set_n_threads(private$ptr_, n_threads)
       private$n_threads_ <- n_threads
       invisible(prev)
     },
@@ -135,7 +145,7 @@
     update_state = function(pars = NULL, state = NULL, time = NULL,
                             set_initial_state = NULL, index = NULL,
                             reset_step_size = NULL) {
-      info <- mode_{{name}}_update_state(private$ptr_, pars, state, time,
+      info <- private$methods_$update_state(private$ptr_, pars, state, time,
                                set_initial_state, index, reset_step_size)
       if (!is.null(pars)) {
         private$pars_ <- pars
@@ -146,33 +156,33 @@
 
     reorder = function(index) {
       storage.mode(index) <- "integer"
-      mode_{{name}}_reorder(private$ptr_, index)
+      private$methods_$reorder(private$ptr_, index)
       invisible()
     },
 
     state = function(index = NULL) {
       if (is.null(index)) {
-        mode_{{name}}_state_full(private$ptr_)
+        private$methods_$state_full(private$ptr_)
       } else {
-        mode_{{name}}_state(private$ptr_, index)
+        private$methods_$state(private$ptr_, index)
       }
     },
 
     resample = function(weights) {
-      invisible(mode_{{name}}_resample(private$ptr_, weights))
+      invisible(private$methods_$resample(private$ptr_, weights))
     },
 
     set_data = function(data, shared = FALSE) {
-      mode_{{name}}_set_data(private$ptr_, data, shared)
+      private$methods_$set_data(private$ptr_, data, shared)
     },
 
     compare_data = function() {
-      mode_{{name}}_compare_data(private$ptr_)
+      private$methods_$compare_data(private$ptr_)
     },
 
     filter = function(time_end = NULL, save_trajectories = FALSE,
                       time_snapshot = NULL, min_log_likelihood = NULL) {
-      mode_{{name}}_filter(private$ptr_, time_end, save_trajectories,
+      private$methods_$filter(private$ptr_, time_end, save_trajectories,
                            time_snapshot, min_log_likelihood)
     },
 
@@ -182,7 +192,7 @@
 
     has_gpu_support = function(fake_gpu = FALSE) {
       if (fake_gpu) {
-        FALSE
+        {{has_gpu_support}}
       } else {
         mode_{{name}}_capabilities()[["gpu"]]
       }

--- a/inst/template/mode.R.template
+++ b/inst/template/mode.R.template
@@ -206,6 +206,15 @@
 
     rng_algorithm = function() {
       mode_{{name}}_capabilities()[["rng_algorithm"]]
+    },
+
+    gpu_info = function() {
+      ret <- mode_{{name}}_gpu_info()
+      parent <- parent.env(environment())
+      if (ret$has_cuda && exists("private", parent, inherits = FALSE)) {
+        ret$config <- private$gpu_config_
+      }
+      ret
     }
   ))
 class({{name}}) <- c("mode_generator", class({{name}}))

--- a/inst/template/mode.R.template
+++ b/inst/template/mode.R.template
@@ -120,7 +120,7 @@
     },
 
     ode_statistics = function() {
-      private$methods_$stats(private$ptr_)
+      private$methods_$ode_statistics(private$ptr_)
     },
 
     n_state = function() {
@@ -161,11 +161,9 @@
     },
 
     state = function(index = NULL) {
-      if (is.null(index)) {
-        private$methods_$state_full(private$ptr_)
-      } else {
-        private$methods_$state(private$ptr_, index)
-      }
+      m <- private$methods_$state(private$ptr_, index)
+      rownames(m) <- names(index)
+      m
     },
 
     resample = function(weights) {

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -1,6 +1,17 @@
 #include <mode/r/mode.hpp>
+#include <dust/r/gpu_info.hpp>
 
 {{model}}
+
+[[cpp11::register]]
+cpp11::sexp mode_{{name}}_capabilities() {
+  return mode::r::mode_capabilities<{{class}}>();
+}
+
+[[cpp11::register]]
+cpp11::sexp mode_{{name}}_gpu_info() {
+  return dust::gpu::r::gpu_info();
+}
 
 using {{name}}_{{target}} = mode::{{container}}<{{class}}>;
 
@@ -93,11 +104,6 @@ void mode_{{name}}_set_n_threads(SEXP ptr, int n_threads) {
 }
 
 [[cpp11::register]]
-cpp11::sexp mode_{{name}}_capabilities() {
-  return mode::r::mode_capabilities<{{class}}>();
-}
-
-[[cpp11::register]]
 SEXP mode_{{name}}_resample(SEXP ptr, cpp11::doubles r_weights) {
   return mode::r::mode_resample<{{name}}_{{target}}>(ptr, r_weights);
   return R_NilValue;
@@ -122,13 +128,4 @@ SEXP mode_{{name}}_filter(SEXP ptr, SEXP time_end, bool save_trajectories,
                                                 save_trajectories,
                                                 time_snapshot,
                                                 min_log_likelihood);
-}
-
-[[cpp11::register]]
-bool mode_{{name}}_has_openmp() {
-#ifdef _OPENMP
-  return true;
-#else
-  return false;
-#endif
 }

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -49,8 +49,8 @@ cpp11::sexp mode_{{name}}_state(SEXP ptr, SEXP index) {
 }
 
 [[cpp11::register]]
-cpp11::sexp mode_{{name}}_stats(SEXP ptr) {
-  return mode::r::mode_stats<mode::container<{{class}}>>(ptr);
+cpp11::sexp mode_{{name}}_ode_statistics(SEXP ptr) {
+  return mode::r::mode_ode_statistics<mode::container<{{class}}>>(ptr);
 }
 
 [[cpp11::register]]

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -2,6 +2,8 @@
 
 {{model}}
 
+using {{name}}_{{target}} = mode::{{container}}<{{class}}>;
+
 [[cpp11::register]]
 SEXP mode_{{name}}_alloc(cpp11::list r_pars, bool pars_multi, double time,
                          cpp11::sexp r_n_particles, size_t n_threads,
@@ -14,43 +16,43 @@ SEXP mode_{{name}}_alloc(cpp11::list r_pars, bool pars_multi, double time,
 
 [[cpp11::register]]
 double mode_{{name}}_time(SEXP ptr) {
-  return mode::r::mode_time<mode::container<{{class}}>>(ptr);
+  return mode::r::mode_time<{{name}}_{{target}}>(ptr);
 }
 
 [[cpp11::register]]
 cpp11::sexp mode_{{name}}_rng_state(SEXP ptr, bool first_only, bool last_only) {
-  return mode::r::mode_rng_state<mode::container<{{class}}>>(ptr, first_only, last_only);
+  return mode::r::mode_rng_state<{{name}}_{{target}}>(ptr, first_only, last_only);
 }
 
 [[cpp11::register]]
 cpp11::sexp mode_{{name}}_set_rng_state(SEXP ptr, cpp11::raws rng_state) {
-  mode::r::mode_set_rng_state<mode::container<{{class}}>>(ptr, rng_state);
+  mode::r::mode_set_rng_state<{{name}}_{{target}}>(ptr, rng_state);
   return R_NilValue;
 }
 
 [[cpp11::register]]
 cpp11::sexp mode_{{name}}_run(SEXP ptr, double time_end) {
-  return mode::r::mode_run<mode::container<{{class}}>>(ptr, time_end);
+  return mode::r::mode_run<{{name}}_{{target}}>(ptr, time_end);
 }
 
 [[cpp11::register]]
 cpp11::sexp mode_{{name}}_simulate(SEXP ptr, cpp11::sexp time_end) {
-  return mode::r::mode_simulate<mode::container<{{class}}>>(ptr, time_end);
+  return mode::r::mode_simulate<{{name}}_{{target}}>(ptr, time_end);
 }
 
 [[cpp11::register]]
 cpp11::sexp mode_{{name}}_state_full(SEXP ptr) {
-  return mode::r::mode_state_full<mode::container<{{class}}>>(ptr);
+  return mode::r::mode_state_full<{{name}}_{{target}}>(ptr);
 }
 
 [[cpp11::register]]
 cpp11::sexp mode_{{name}}_state(SEXP ptr, SEXP index) {
-  return mode::r::mode_state<mode::container<{{class}}>>(ptr, index);
+  return mode::r::mode_state<{{name}}_{{target}}>(ptr, index);
 }
 
 [[cpp11::register]]
 cpp11::sexp mode_{{name}}_ode_statistics(SEXP ptr) {
-  return mode::r::mode_ode_statistics<mode::container<{{class}}>>(ptr);
+  return mode::r::mode_ode_statistics<{{name}}_{{target}}>(ptr);
 }
 
 [[cpp11::register]]
@@ -67,32 +69,32 @@ cpp11::sexp mode_{{name}}_update_state(SEXP ptr,
 
 [[cpp11::register]]
 void mode_{{name}}_set_index(SEXP ptr, SEXP index) {
-  return mode::r::mode_set_index<mode::container<{{class}}>>(ptr, index);
+  return mode::r::mode_set_index<{{name}}_{{target}}>(ptr, index);
 }
 
 [[cpp11::register]]
 void mode_{{name}}_set_stochastic_schedule(SEXP ptr, SEXP time) {
-  return mode::r::mode_set_stochastic_schedule<mode::container<{{class}}>>(ptr, time);
+  return mode::r::mode_set_stochastic_schedule<{{name}}_{{target}}>(ptr, time);
 }
 
 [[cpp11::register]]
 size_t mode_{{name}}_n_variables(SEXP ptr) {
-  return mode::r::mode_n_variables<mode::container<{{class}}>>(ptr);
+  return mode::r::mode_n_variables<{{name}}_{{target}}>(ptr);
 }
 
 [[cpp11::register]]
 size_t mode_{{name}}_n_state(SEXP ptr) {
-  return mode::r::mode_n_state<mode::container<{{class}}>>(ptr);
+  return mode::r::mode_n_state<{{name}}_{{target}}>(ptr);
 }
 
 [[cpp11::register]]
 void mode_{{name}}_reorder(SEXP ptr, SEXP index) {
-  return mode::r::mode_reorder<mode::container<{{class}}>>(ptr, index);
+  return mode::r::mode_reorder<{{name}}_{{target}}>(ptr, index);
 }
 
 [[cpp11::register]]
 void mode_{{name}}_set_n_threads(SEXP ptr, int n_threads) {
-  return mode::r::mode_set_n_threads<mode::container<{{class}}>>(ptr, n_threads);
+  return mode::r::mode_set_n_threads<{{name}}_{{target}}>(ptr, n_threads);
 }
 
 [[cpp11::register]]
@@ -102,26 +104,26 @@ cpp11::sexp mode_{{name}}_capabilities() {
 
 [[cpp11::register]]
 SEXP mode_{{name}}_resample(SEXP ptr, cpp11::doubles r_weights) {
-  return mode::r::mode_resample<mode::container<{{class}}>>(ptr, r_weights);
+  return mode::r::mode_resample<{{name}}_{{target}}>(ptr, r_weights);
   return R_NilValue;
 }
 
 [[cpp11::register]]
 SEXP mode_{{name}}_set_data(SEXP ptr, cpp11::list data, bool shared) {
-  mode::r::mode_set_data<mode::container<{{class}}>>(ptr, data, shared);
+  mode::r::mode_set_data<{{name}}_{{target}}>(ptr, data, shared);
   return R_NilValue;
 }
 
 [[cpp11::register]]
 SEXP mode_{{name}}_compare_data(SEXP ptr) {
-  return mode::r::mode_compare_data<mode::container<{{class}}>>(ptr);
+  return mode::r::mode_compare_data<{{name}}_{{target}}>(ptr);
 }
 
 [[cpp11::register]]
 SEXP mode_{{name}}_filter(SEXP ptr, SEXP time_end, bool save_trajectories,
                           cpp11::sexp time_snapshot,
                           cpp11::sexp min_log_likelihood) {
-  return mode::r::mode_filter<mode::container<{{class}}>>(ptr, time_end,
+  return mode::r::mode_filter<{{name}}_{{target}}>(ptr, time_end,
                                                 save_trajectories,
                                                 time_snapshot,
                                                 min_log_likelihood);

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -41,11 +41,6 @@ cpp11::sexp mode_{{name}}_simulate(SEXP ptr, cpp11::sexp time_end) {
 }
 
 [[cpp11::register]]
-cpp11::sexp mode_{{name}}_state_full(SEXP ptr) {
-  return mode::r::mode_state_full<{{name}}_{{target}}>(ptr);
-}
-
-[[cpp11::register]]
 cpp11::sexp mode_{{name}}_state(SEXP ptr, SEXP index) {
   return mode::r::mode_state<{{name}}_{{target}}>(ptr, index);
 }

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -708,3 +708,20 @@ test_that("dummy data methods error on use", {
     mod$filter(),
     "The 'filter' method is not supported for this class")
 })
+
+
+test_that("can retrieve empty params", {
+  ex <- example_logistic()
+  mod <- ex$generator$new(ex$pars, 0, 10)
+  expect_null(mod$param())
+})
+
+
+test_that("can retrieve empty gpu info", {
+  ex <- example_logistic()
+  mod <- ex$generator$new(ex$pars, 0, 10)
+  ## Another dust model that lacks gpu information; use this as an
+  ## expected template:
+  expected <- dust::dust_example("sir")$new(list(), 0, 1)$gpu_info()
+  expect_equal(mod$gpu_info(), expected)
+})


### PR DESCRIPTION
Because dust supports both gpu and cpu models there's a bit of a faff with setting up pointers to the actual methods. Mode has never needed that but will once we share a template. There's a corresponding tweak in the .cpp itself to allow the template substitution to pick the target (here `ode`) and the container (here `dust_ode`)

With this, the dust.R.template and mode.R.template should be basically identical aside from swapping mode for dust. The mode.cpp file contains the same contents as the associated files in dust (it's split across a few files).

There's a couple of other small tweaks here:

* a new param method (and corresponding empty bit in the template); this will become clearer once we merge with dust as there's a dance there to get nice parameter information (what does the model need in order to be created) from it
* tweaks to the `state()` method to move the logic from the R template into the C++, matching dust
* a new `gpu_info` method which I should have added in #41 probably, but does very little