### PR TITLE
Refactor update_state to match dust

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - main
 
 name: make-release
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mode
 Title: Solve Multiple ODEs
-Version: 0.1.12
+Version: 0.1.13
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = c("aut"),

--- a/inst/examples/logistic.cpp
+++ b/inst/examples/logistic.cpp
@@ -1,3 +1,4 @@
+// [[dust::time_type(continuous)]]
 class logistic {
 public:
   using real_type = double;
@@ -59,9 +60,13 @@ namespace dust {
 template <>
 dust::pars_type<logistic> dust_pars<logistic>(cpp11::list pars) {
   using real_type = logistic::real_type;
+  // [[dust::param(r1, required = TRUE)]]
   real_type r1 = cpp11::as_cpp<double>(pars["r1"]);
+  // [[dust::param(K1, required = TRUE)]]
   real_type K1 = cpp11::as_cpp<double>(pars["K1"]);
+  // [[dust::param(r2, required = TRUE)]]
   real_type r2 = cpp11::as_cpp<double>(pars["r2"]);
+  // [[dust::param(K2, required = TRUE)]]
   real_type K2 = cpp11::as_cpp<double>(pars["K2"]);
 
   logistic::shared_type shared{r1, K1, r2, K2};

--- a/inst/examples/stochastic.cpp
+++ b/inst/examples/stochastic.cpp
@@ -1,3 +1,4 @@
+// [[dust::time_type(continuous)]]
 class logistic {
 public:
   using real_type = double;
@@ -66,10 +67,15 @@ namespace dust {
 template <>
 dust::pars_type<logistic> dust_pars<logistic>(cpp11::list pars) {
   using real_type = logistic::real_type;
+  // [[dust::param(r1, required = TRUE)]]
   real_type r1 = cpp11::as_cpp<real_type>(pars["r1"]);
+  // [[dust::param(K1, required = TRUE)]]
   real_type K1 = cpp11::as_cpp<real_type>(pars["K1"]);
+  // [[dust::param(r2, required = TRUE)]]
   real_type r2 = cpp11::as_cpp<real_type>(pars["r2"]);
+  // [[dust::param(K2, required = TRUE)]]
   real_type K2 = cpp11::as_cpp<real_type>(pars["K2"]);
+  // [[dust::param(v, required = TRUE)]]
   real_type v = cpp11::as_cpp<real_type>(pars["v"]);
 
   logistic::shared_type shared{r1, K1, r2, K2, v};

--- a/inst/include/mode/mode.hpp
+++ b/inst/include/mode/mode.hpp
@@ -178,18 +178,18 @@ public:
 #pragma omp parallel for schedule(static) num_threads(n_threads_)
 #endif
     for (size_t i = 0; i < n_particles_; ++i) {
-      solver_[i].set_time(t, false);
+      solver_[i].set_time(time, false);
     }
   }
 
   void set_state(const std::vector<real_type>& state,
                  const std::vector<size_t>& index) {
-    const size_t n_particles = particles_.size();
     const bool use_index = index.size() > 0;
     const size_t n_state = use_index ? index.size() : n_state_full();
-    const bool individual = state.size() == n_state * n_particles;
-    const size_t n = individual ? 1 : n_particles_each_;
+    const bool individual = state.size() == n_state * n_particles_;
+    const size_t n = individual ? 1 : n_particles_; // really n_particles_each_
     auto it = state.begin();
+    const auto t = time();
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) num_threads(n_threads_)

--- a/inst/include/mode/mode.hpp
+++ b/inst/include/mode/mode.hpp
@@ -195,7 +195,6 @@ public:
 #endif
     for (size_t i = 0; i < n_particles_; ++i) {
       const auto it_i = it + (i / n) * n_state;
-      // TODO: no real need to take 't' here at all.
       if (use_index) {
         solver_[i].set_state(it_i, index);
       } else {

--- a/inst/include/mode/mode.hpp
+++ b/inst/include/mode/mode.hpp
@@ -178,7 +178,7 @@ public:
 #pragma omp parallel for schedule(static) num_threads(n_threads_)
 #endif
     for (size_t i = 0; i < n_particles_; ++i) {
-      solver_[i].set_time(time, false);
+      solver_[i].set_time(time);
     }
   }
 
@@ -189,7 +189,6 @@ public:
     const bool individual = state.size() == n_state * n_particles_;
     const size_t n = individual ? 1 : n_particles_; // really n_particles_each_
     auto it = state.begin();
-    const auto t = time();
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) num_threads(n_threads_)
@@ -198,9 +197,9 @@ public:
       const auto it_i = it + (i / n) * n_state;
       // TODO: no real need to take 't' here at all.
       if (use_index) {
-        solver_[i].set_state(t, it_i, index);
+        solver_[i].set_state(it_i, index);
       } else {
-        solver_[i].set_state(t, it_i);
+        solver_[i].set_state(it_i);
       }
     }
   }
@@ -233,8 +232,7 @@ public:
 #pragma omp parallel for schedule(static) num_threads(n_threads_)
 #endif
       for (size_t i = 0; i < n_particles_; ++i) {
-        solver_[i].set_state(t, y);
-        solver_[i].initialise(t);
+        solver_[i].set_state(y);
       }
     }
   }
@@ -253,6 +251,7 @@ public:
     for (size_t i = 0; i < n_particles_; ++i) {
       solver_[i].swap();
     }
+    initialise(false);
   }
 
   void statistics(std::vector<size_t> &all_stats) {

--- a/inst/include/mode/mode.hpp
+++ b/inst/include/mode/mode.hpp
@@ -50,7 +50,7 @@ public:
     return m_.n_variables() + m_.n_output();
   }
 
-  size_t n_state_run() const {
+  size_t n_state() const {
     return index_.size();
   }
 
@@ -122,8 +122,7 @@ public:
 
   std::vector<double> simulate(const std::vector<double>& time_end) {
     const size_t n_time = time_end.size();
-    const size_t n_state = n_state_run();
-    std::vector<double> ret(n_particles() * n_state * n_time);
+    std::vector<double> ret(n_particles() * n_state() * n_time);
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) num_threads(n_threads_)
@@ -132,7 +131,7 @@ public:
       try {
         for (size_t t = 0; t < n_time; ++t) {
           solver_[i].solve(time_end[t], rng_.state(i));
-          size_t offset = t * n_state * n_particles() + i * n_state;
+          size_t offset = t * n_state() * n_particles() + i * n_state();
           solver_[i].state(index_, ret.begin() + offset);
         }
       } catch (std::exception const& e) {
@@ -159,7 +158,7 @@ public:
 #pragma omp parallel for schedule(static) num_threads(n_threads_)
 #endif
     for (size_t i = 0; i < n_particles_; ++i) {
-      solver_[i].state(index_, it + i * n_state_run());
+      solver_[i].state(index_, it + i * n_state());
     }
   }
 

--- a/inst/include/mode/mode.hpp
+++ b/inst/include/mode/mode.hpp
@@ -217,52 +217,6 @@ public:
     }
   }
 
-  void update_state(std::vector<double> time,
-                    const std::vector<double>& state,
-                    const std::vector<size_t>& index,
-                    bool set_initial_state,
-                    bool reset_step_size) {
-    auto t = solver_[0].time();
-    if (time.size() > 0) {
-      t = time[0];
-    }
-    if (state.size() > 0) {
-      size_t n = index.size();
-      const bool individual = state.size() == n * n_particles_;
-      auto it = state.begin();
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static) num_threads(n_threads_)
-#endif
-      for (size_t i = 0; i < n_particles_; ++i) {
-        auto start = it;
-        if (individual) {
-            start = it + i * n;
-        }
-        solver_[i].set_state(t, start, index);
-        solver_[i].set_time(t, reset_step_size);
-        solver_[i].initialise(t);
-      }
-    } else if (set_initial_state) {
-      auto y = m_.initial(t);
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static) num_threads(n_threads_)
-#endif
-      for (size_t i = 0; i < n_particles_; ++i) {
-        solver_[i].set_state(t, y, index);
-        solver_[i].set_time(t, reset_step_size);
-        solver_[i].initialise(t);
-      }
-    } else {
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static) num_threads(n_threads_)
-#endif
-      for (size_t i = 0; i < n_particles_; ++i) {
-        solver_[i].set_time(t, reset_step_size);
-        solver_[i].initialise(t);
-      }
-    }
-  }
-
   void set_pars(const pars_type& pars, bool set_initial_state) {
     m_ = model_type(pars);
 #ifdef _OPENMP

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -205,9 +205,9 @@ cpp11::sexp mode_update_state_set_pars(T *obj, cpp11::list r_pars,
                                        bool set_initial_state) {
   using model_type = typename T::model_type;
   cpp11::sexp ret = R_NilValue;
-  dust::pars_type<model_type> pars = dust_pars<model_type>(r_pars);
+  dust::pars_type<model_type> pars = dust::dust_pars<model_type>(r_pars);
   obj->set_pars(pars, set_initial_state);
-  ret = dust_info<model_type>(pars);
+  ret = dust::dust_info<model_type>(pars);
   return ret;
 }
 

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -255,6 +255,7 @@ SEXP mode_update_state(SEXP ptr, SEXP r_pars, SEXP r_state, SEXP r_time,
                        SEXP r_set_initial_state, SEXP r_index,
                        SEXP reset_step_size) {
   using real_type = typename T::real_type;
+  using time_type = typename T::time_type;
   T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
 
   const bool has_time = r_time != R_NilValue;
@@ -283,12 +284,12 @@ SEXP mode_update_state(SEXP ptr, SEXP r_pars, SEXP r_state, SEXP r_time,
   // function having dealt with both or neither (i.e., do not fail on
   // time after succeeding on state).
 
-  std::vector<typename T::time_type> time;
+  std::vector<time_type> time;
   std::vector<real_type> state;
 
   if (has_time) {
-    // TODO: simplify this, if possible
-    time = dust::r::validate_size(r_time, "time");
+    const time_type t0 = 0;
+    time = dust::r::validate_time<std::vector<time_type>>(r_time, t0, "time");
     const size_t len = time.size();
     if (len != 1) {
       cpp11::stop("Expected 'time' to be scalar");

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -135,9 +135,9 @@ cpp11::sexp mode_run(SEXP ptr, cpp11::sexp r_time_end) {
     dust::r::validate_time<time_type>(r_time_end, obj->time(), "time_end");
   obj->run(time_end);
 
-  std::vector<double> dat(obj->n_state_run() * obj->n_particles());
+  std::vector<double> dat(obj->n_state() * obj->n_particles());
   obj->state(dat);
-  return mode::r::state_array(dat, obj->n_state_run(), obj->n_particles());
+  return mode::r::state_array(dat, obj->n_state(), obj->n_particles());
 }
 
 template <typename T>
@@ -149,7 +149,7 @@ cpp11::sexp mode_simulate(SEXP ptr, cpp11::sexp r_time_end) {
   obj->check_errors();
   auto dat = obj->simulate(time_end);
 
-  return mode::r::state_array(dat, obj->n_state_run(), obj->n_particles(),
+  return mode::r::state_array(dat, obj->n_state(), obj->n_particles(),
                               time_end.size());
 }
 

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -243,6 +243,10 @@ cpp11::sexp mode_update_state_set(T *obj, SEXP r_pars,
     obj->set_state(state, index);
   }
 
+  // TODO: this is something with no real dust analogue, but needs
+  // adding (e.g., a dummy method) along with this call so that things
+  // work. Alternatively we wrap this up and test for presence of the
+  // method, or of the time type?
   obj->initialise(reset_step_size);
 
   // If we set both initial conditions and time then we're safe to

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -48,7 +48,7 @@ cpp11::list mode_alloc(cpp11::list r_pars, bool pars_multi, cpp11::sexp r_time,
 }
 
 template <typename T>
-void mode_set_n_threads(SEXP ptr, size_t n_threads) {
+void mode_set_n_threads(SEXP ptr, int n_threads) {
   T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
   mode::r::validate_positive(n_threads, "n_threads");
   obj->set_n_threads(n_threads);
@@ -201,51 +201,118 @@ cpp11::sexp mode_ode_statistics(SEXP ptr) {
 }
 
 template <typename T>
-cpp11::sexp mode_update_state(SEXP ptr, SEXP r_pars, SEXP r_state, SEXP r_time,
-                              SEXP r_set_initial_state,
-                              SEXP r_index, SEXP r_reset_step_size) {
-  mode::dust_ode<T> *obj =
-      cpp11::as_cpp < cpp11::external_pointer<mode::dust_ode<T>>>(ptr).get();
+cpp11::sexp mode_update_state_set_pars(T *obj, cpp11::list r_pars,
+                                       bool set_initial_state) {
+  using model_type = typename T::model_type;
+  cpp11::sexp ret = R_NilValue;
+  dust::pars_type<model_type> pars = dust_pars<model_type>(r_pars);
+  obj->set_pars(pars, set_initial_state);
+  ret = dust_info<model_type>(pars);
+  return ret;
+}
 
-  std::vector<size_t> index;
-  const size_t index_max = obj->n_variables();
-  if (r_index != R_NilValue) {
-    index = mode::r::r_index_to_index(r_index, index_max);
-  } else {
-    index.clear();
-    index.reserve(index_max);
-    for (size_t i = 0; i < index_max; ++i) {
-      index.push_back(i);
+// There are many components of state (not including rng state which
+// we treat separately), we set components always in the order (1)
+// time, (2) pars, (3) state
+template <typename T, typename real_type>
+cpp11::sexp mode_update_state_set(T *obj, SEXP r_pars,
+                                  const std::vector<real_type>& state,
+                                  const std::vector<typename T::time_type>& time,
+                                  bool set_initial_state,
+                                  const std::vector<size_t>& index) {
+  cpp11::sexp ret = R_NilValue;
+  const auto time_prev = obj->time();
+
+  if (time.size() == 1) {
+    obj->set_time(time[0]);
+  }
+
+  if (r_pars != R_NilValue) {
+    try {
+      ret = mode_update_state_set_pars(obj, cpp11::as_cpp<cpp11::list>(r_pars),
+                                       set_initial_state);
+    } catch (const std::invalid_argument& e) {
+      obj->set_time(time_prev);
+      throw e;
     }
   }
 
-  const size_t n_state_full = obj->n_state_full();
-
-  auto set_initial_state = mode::r::validate_set_initial_state(r_state,
-                                                               r_pars,
-                                                               r_time,
-                                                               r_set_initial_state);
-  auto reset_step_size = mode::r::validate_reset_step_size(r_time,
-                                                           r_pars,
-                                                           r_reset_step_size);
-  auto time = mode::r::validate_time(r_time);
-  auto state = mode::r::validate_state(r_state,
-                                       index.size(),
-                                       n_state_full,
-                                       static_cast<int>(obj->n_particles()));
-  cpp11::sexp ret = R_NilValue;
-  if (r_pars != R_NilValue) {
-    auto pars = dust::dust_pars<T>(r_pars);
-    obj->set_pars(pars);
-    ret = dust::dust_info<T>(pars);
+  if (state.size() > 0) { // && !set_initial_state, though that is implied
+    obj->set_state(state, index);
   }
-  // NOTE: there's no equivalent to this in dust, with all the work
-  // done at the 'r/' level, so we don't try and preserve much about
-  // the order of variables here (partly because everywhere else
-  // within the ode work we do (time, state) not (state, time) as on
-  // entry here.
-  obj->update_state(time, state, index, set_initial_state, reset_step_size);
+
+  // If we set both initial conditions and time then we're safe to
+  // continue here.
+  if ((set_initial_state || state.size() > 0) && time.size() > 0) {
+    obj->reset_errors();
+  }
+
   return ret;
+}
+
+template <typename T>
+SEXP mode_update_state(SEXP ptr, SEXP r_pars, SEXP r_state, SEXP r_time,
+                       SEXP r_set_initial_state, SEXP r_index,
+                       SEXP reset_step_size) {
+  using real_type = typename T::real_type;
+  T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
+
+  const bool has_time = r_time != R_NilValue;
+  const bool has_pars = r_pars != R_NilValue;
+  const bool has_state = r_state != R_NilValue;
+  const bool has_index = r_index != R_NilValue;
+
+  bool set_initial_state = false;
+  if (r_set_initial_state == R_NilValue) {
+    set_initial_state = !has_state && has_pars && has_time;
+  } else {
+    set_initial_state = cpp11::as_cpp<bool>(r_set_initial_state);
+  }
+
+  if (set_initial_state && !has_pars) {
+    cpp11::stop("Can't use 'set_initial_state' without providing 'pars'");
+  }
+  if (set_initial_state && has_state) {
+    cpp11::stop("Can't use both 'set_initial_state' and provide 'state'");
+  }
+  if (has_index && !has_state) {
+    cpp11::stop("Can't provide 'index' without providing 'state'");
+  }
+
+  // Do the validation on both arguments first so that we leave this
+  // function having dealt with both or neither (i.e., do not fail on
+  // time after succeeding on state).
+
+  std::vector<typename T::time_type> time;
+  std::vector<real_type> state;
+
+  if (has_time) {
+    // TODO: simplify this, if possible
+    time = dust::r::validate_size(r_time, "time");
+    const size_t len = time.size();
+    if (len != 1) {
+      cpp11::stop("Expected 'time' to be scalar");
+    }
+  }
+
+  std::vector<size_t> index;
+
+  if (has_state) {
+    if (has_index) {
+      index = dust::r::r_index_to_index(r_index, obj->n_state_full());
+      if (index.size() == 0) {
+        cpp11::stop("Expected at least one element in 'index'");
+      }
+    }
+    const size_t expected_len = has_index ? index.size() : obj->n_state_full();
+    state = dust::r::check_state<real_type>(r_state,
+                                            expected_len,
+                                            obj->shape(),
+                                            obj->pars_are_shared());
+  }
+
+  return mode_update_state_set(obj, r_pars, state, time, set_initial_state,
+                               index);
 }
 
 template <typename T>

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -232,7 +232,8 @@ cpp11::sexp mode_update_state_set(T *obj, SEXP r_pars,
     try {
       ret = mode_update_state_set_pars(obj, cpp11::as_cpp<cpp11::list>(r_pars),
                                        set_initial_state);
-    } catch (const std::invalid_argument& e) {
+    } catch (const std::exception& e) {
+      // TODO: this needs relaxing in dust; we don't catch this error atm.
       obj->set_time(time_prev);
       throw e;
     }

--- a/inst/include/mode/r/mode.hpp
+++ b/inst/include/mode/r/mode.hpp
@@ -255,12 +255,6 @@ size_t mode_n_state(SEXP ptr) {
 }
 
 template <typename T>
-size_t mode_n_variables(SEXP ptr) {
-  T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
-  return obj->n_variables();
-}
-
-template <typename T>
 void mode_reorder(SEXP ptr, cpp11::sexp r_index) {
   T *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
   const size_t index_max = obj->n_particles();

--- a/inst/include/mode/solver.hpp
+++ b/inst/include/mode/solver.hpp
@@ -159,6 +159,10 @@ public:
     stepper_.initialise(t);
   }
 
+  void initialise() {
+    stepper_.initialise(t_);
+  }
+
   void set_state(double t,
                  const std::vector<double> &state) {
     set_state(t, state.begin());

--- a/inst/include/mode/solver.hpp
+++ b/inst/include/mode/solver.hpp
@@ -35,7 +35,8 @@ public:
                         n_variables_(m.n_variables()),
                         n_output_(m.n_output()) {
     stats_.reset();
-    set_state(t, y);
+    set_state(y);
+    initialise();
     set_initial_step_size();
   }
 
@@ -128,13 +129,10 @@ public:
     stochastic_schedule_ = time;
   }
 
-  void set_time(double t, bool reset_step_size) {
+  void set_time(double t) {
     if (t != t_) {
       stats_.reset();
       t_ = t;
-    }
-    if (reset_step_size) {
-      set_initial_step_size();
     }
   }
 
@@ -142,36 +140,26 @@ public:
     h_ = stepper_.init_step_size(t_, ctl_);
   }
 
-  void set_state(double t,
-                 std::vector<double>::const_iterator state) {
-    stepper_.set_state(t, state);
-    stepper_.initialise(t);
+  void set_state(std::vector<double>::const_iterator state) {
+    stepper_.set_state(state);
   }
 
-  void set_state(double t,
-                 std::vector<double>::const_iterator state,
+  void set_state(std::vector<double>::const_iterator state,
                  const std::vector<size_t>& index) {
-    stepper_.set_state(t, state, index);
-    stepper_.initialise(t);
-  }
-
-  void initialise(double t) {
-    stepper_.initialise(t);
+    stepper_.set_state(state, index);
   }
 
   void initialise() {
     stepper_.initialise(t_);
   }
 
-  void set_state(double t,
-                 const std::vector<double> &state) {
-    set_state(t, state.begin());
+  void set_state(const std::vector<double> &state) {
+    set_state(state.begin());
   }
 
-  void set_state(double t,
-                 const std::vector<double> &state,
+  void set_state(const std::vector<double> &state,
                  const std::vector<size_t>& index) {
-    set_state(t, state.begin(), index);
+    set_state(state.begin(), index);
   }
 
   void set_state(const solver<Model>& other) {

--- a/inst/include/mode/stepper.hpp
+++ b/inst/include/mode/stepper.hpp
@@ -119,15 +119,13 @@ public:
     return std::sqrt(err / n_var);
   }
 
-  void set_state(double t,
-                 std::vector<double>::const_iterator state) {
+  void set_state(std::vector<double>::const_iterator state) {
     for (size_t i = 0; i < n_var; ++i, ++state) {
       y[i] = *state;
     }
   }
 
-  void set_state(double t,
-                 std::vector<double>::const_iterator state,
+  void set_state(std::vector<double>::const_iterator state,
                  const std::vector<size_t>& index) {
     for (size_t i = 0; i < index.size(); ++i, ++state) {
       y[index[i]] = *state;

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -84,11 +84,6 @@ void mode_{{name}}_set_stochastic_schedule(SEXP ptr, SEXP time) {
 }
 
 [[cpp11::register]]
-size_t mode_{{name}}_n_variables(SEXP ptr) {
-  return mode::r::mode_n_variables<{{name}}_{{target}}>(ptr);
-}
-
-[[cpp11::register]]
 size_t mode_{{name}}_n_state(SEXP ptr) {
   return mode::r::mode_n_state<{{name}}_{{target}}>(ptr);
 }

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -17,7 +17,7 @@ using {{name}}_{{target}} = mode::{{container}}<{{class}}>;
 
 [[cpp11::register]]
 SEXP mode_{{name}}_alloc(cpp11::list r_pars, bool pars_multi, cpp11::sexp r_time,
-                         cpp11::sexp r_n_particles, size_t n_threads,
+                         cpp11::sexp r_n_particles, int n_threads,
                          cpp11::sexp r_seed, bool deterministic,
                          cpp11::sexp r_gpu_config, cpp11::sexp r_ode_control) {
   return mode::r::mode_alloc<{{class}}>(r_pars, pars_multi, r_time, r_n_particles,
@@ -84,7 +84,7 @@ void mode_{{name}}_set_stochastic_schedule(SEXP ptr, SEXP time) {
 }
 
 [[cpp11::register]]
-size_t mode_{{name}}_n_state(SEXP ptr) {
+int mode_{{name}}_n_state(SEXP ptr) {
   return mode::r::mode_n_state<{{name}}_{{target}}>(ptr);
 }
 

--- a/inst/template/mode.cpp
+++ b/inst/template/mode.cpp
@@ -69,7 +69,7 @@ cpp11::sexp mode_{{name}}_update_state(SEXP ptr,
                                        SEXP set_initial_state,
                                        SEXP index,
                                        SEXP reset_step_size) {
-  return mode::r::mode_update_state<{{class}}>(ptr,
+  return mode::r::mode_update_state<{{name}}_{{target}}>(ptr,
       pars, state, time, set_initial_state, index, reset_step_size);
 }
 

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -367,11 +367,11 @@ test_that("A null schedule clears stochastic schedule", {
   expect_equal(y, apply(exp(rng$normal(6, 0, 0.1)), 2, prod))
 
   ## reset and rerun, draw another set:
-  mod$update_state(time = 0)
+  mod$update_state(time = 0, pars = pars, set_initial_state = TRUE)
   y <- drop(mod$run(10))
   expect_equal(y, apply(exp(rng$normal(6, 0, 0.1)), 2, prod))
 
-  mod$update_state(time = 0)
+  mod$update_state(time = 0, pars = pars, set_initial_state = TRUE)
   mod$set_stochastic_schedule(NULL)
   y <- drop(mod$run(10))
   expect_equal(y, rep(1, np))
@@ -426,14 +426,13 @@ test_that("Can get state when multi-threaded", {
 test_that("Can update state when multi-threaded", {
   ex <- example_logistic()
   np <- 3
-  mod <- ex$generator$new(ex$pars, 0, np, n_threads = 4)
-  mod$run(3)
+  mod <- ex$generator$new(ex$pars, 0, np, n_threads = 1)
+  y <- mod$run(3)
 
   new_pars <- list(r1 = 0.5, r2 = 0.7, K1 = 200, K2 = 200)
 
   # update all particles to have the same state
-  mod$update_state(pars = new_pars, time = 2,
-                            state = c(1, 2))
+  mod$update_state(pars = new_pars, time = 2, state = c(1, 2))
 
   expect_equal(mod$state(), matrix(rep(1:3, np), nrow = 3))
   expect_equal(mod$time(), 2)
@@ -606,7 +605,7 @@ test_that("can set an index and reflect that in simulate output", {
   expect_equal(dim(m), c(2, n_particles, length(t)))
 
   ## Same as the full output:
-  mod$update_state(time = 0, set_initial_state = TRUE)
+  mod$update_state(time = 0, pars = ex$pars, set_initial_state = TRUE)
   mod$set_index(NULL)
   expect_identical(unname(m), mod$simulate(t)[2:3, , ])
 })

--- a/tests/testthat/test-updating-state.R
+++ b/tests/testthat/test-updating-state.R
@@ -152,6 +152,8 @@ test_that("Can update state with a matrix", {
   expect_identical(state[1, ] + state[2, ], state[3, ])
 })
 
+## Leaving these two tests, disabled, until after merging with dust;
+## then we can adjust the checks to re-enable this.
 test_that("Output indexes ignored when updating by vector", {
   skip("currently disabled")
   path <- mode_file("examples/logistic.cpp")

--- a/tests/testthat/test-updating-state.R
+++ b/tests/testthat/test-updating-state.R
@@ -24,12 +24,12 @@ test_that("Can only update time for all particles at once", {
   initial_time <- 1
   mod <- gen$new(pars, initial_time, n_particles)
   expect_error(mod$update_state(time = c(1, 2, 3, 4, 5)),
-               "Expected 'time' to be a scalar value")
+               "Expected 'time' to be scalar")
   expect_equal(mod$time(), initial_time)
 })
 
 test_that(
-  "Updating time does not reset state iff set_initial_state is FAlSE", {
+  "Updating time does not reset state if set_initial_state is FALSE", {
   path <- mode_file("examples/logistic.cpp")
   gen <- mode(path, quiet = TRUE)
   pars <- list(r1 = 0.1, r2 = 0.2, K1 = 100, K2 = 100)
@@ -37,12 +37,12 @@ test_that(
   mod <- gen$new(pars, initial_time, 5)
   res <- mod$run(5)
 
-  mod$update_state(time = initial_time)
+  mod$update_state(time = initial_time, pars = pars, set_initial_state = TRUE)
   res2 <- mod$run(5)
   # expect results to be identical because state was reset
   expect_true(identical(res, res2))
 
-  mod$update_state(time = initial_time, set_initial_state = FALSE)
+  mod$update_state(time = initial_time, pars = pars, set_initial_state = FALSE)
   res3 <- mod$run(5)
   # expect results to be different because state was not reset
   expect_false(identical(res, res3))
@@ -72,7 +72,7 @@ test_that("Updating time does not reset state if new state is provided", {
   expect_equal(mod$time(), initial_time)
   res_t2 <- mod$run(2)
   res_t3 <- mod$run(3)
-  mod$update_state(time = initial_time, state = res_t2[, 1])
+  mod$update_state(time = initial_time, state = res_t2[1:2, 1])
   res2_t2 <- mod$run(2)
   expect_equal(res_t3, res2_t2, tolerance = 1e-7)
 })
@@ -86,7 +86,7 @@ test_that("'set_initial_state' cannot be TRUE unless 'state' is NULL", {
   mod <- gen$new(pars, initial_time, n_particles)
   expect_equal(mod$time(), initial_time)
   expect_error(mod$update_state(state = c(2, 2), set_initial_state = TRUE),
-               "'set_initial_state' cannot be TRUE unless 'state' is NULL")
+               "Can't use 'set_initial_state' without providing 'pars'")
 })
 
 test_that("Error if state vector does not have correct length", {
@@ -96,9 +96,9 @@ test_that("Error if state vector does not have correct length", {
   n_particles <- 5
   mod <- gen$new(pars, 1, n_particles)
   expect_error(mod$update_state(state = c(1, 2, 3, 4, 5)),
-               "Expected 'state' to be a vector of length 2 but was length 5")
+               "Expected a vector of length 2 for 'state' but given 5")
   expect_error(mod$update_state(state = c(1, 2), index = 1),
-               "Expected 'state' to be a vector of length 1 but was length 2")
+               "Expected a vector of length 1 for 'state' but given 2")
 })
 
 test_that("Error if state matrix does not have correct dimensions", {
@@ -109,15 +109,15 @@ test_that("Error if state matrix does not have correct dimensions", {
   mod <- gen$new(pars, 1, n_particles)
   # check wrong ncol
   expect_error(mod$update_state(state = matrix(1, nrow = 2, ncol = 3)),
-               "Expected 'state' to be a 2 by 5 matrix but was 2 by 3")
+               "Expected a matrix with 5 cols for 'state' but given 3")
   # check wrong nrow
   expect_error(mod$update_state(state = matrix(1, nrow = 4, ncol = 5)),
-               "Expected 'state' to be a 2 by 5 matrix but was 4 by 5")
+               "Expected a matrix with 2 rows for 'state' but given 4")
 
   # check wrong with index
   expect_error(mod$update_state(state = matrix(1, nrow = 2, ncol = 5),
                                 index = 1),
-               "Expected 'state' to be a 1 by 5 matrix but was 2 by 5")
+               "Expected a matrix with 1 rows for 'state' but given 2")
 })
 
 test_that("Can update state with a vector", {
@@ -128,7 +128,7 @@ test_that("Can update state with a vector", {
   mod <- gen$new(pars, 0, n_particles)
   res <- vapply(1:10, function(t) mod$run(t),
                 matrix(0.0, 3, n_particles))
-  prev_state <- res[, 1, 10]
+  prev_state <- res[1:2, 1, 10]
   new_state <- prev_state + 10
   mod$update_state(state = new_state)
   state <- mod$state()
@@ -144,7 +144,7 @@ test_that("Can update state with a matrix", {
   mod <- gen$new(pars, 0, n_particles)
   res <- vapply(1:10, function(t) mod$run(t),
                 matrix(0.0, 3, n_particles))
-  prev_state <- res[, 1, 10]
+  prev_state <- res[1:2, 1, 10]
   new_state <- cbind(prev_state + 10, prev_state + 11, prev_state + 12)
   mod$update_state(state = new_state)
   state <- mod$state()
@@ -153,6 +153,7 @@ test_that("Can update state with a matrix", {
 })
 
 test_that("Output indexes ignored when updating by vector", {
+  skip("currently disabled")
   path <- mode_file("examples/logistic.cpp")
   gen <- mode(path, quiet = TRUE)
   pars <- list(r1 = 0.1, r2 = 0.2, K1 = 100, K2 = 100)
@@ -163,6 +164,7 @@ test_that("Output indexes ignored when updating by vector", {
 })
 
 test_that("Output indexes ignored when updating by matrix", {
+  skip("currently disabled")
   path <- mode_file("examples/logistic.cpp")
   gen <- mode(path, quiet = TRUE)
   pars <- list(r1 = 0.1, r2 = 0.2, K1 = 100, K2 = 100)
@@ -183,7 +185,7 @@ test_that("Can update state with a vector and index", {
   mod <- gen$new(pars, 0, n_particles)
   res <- vapply(1:10, function(t) mod$run(t),
                 matrix(0.0, 3, n_particles))
-  prev_state <- res[, 1, 10]
+  prev_state <- res[1:2, 1, 10]
   new_state <- prev_state + 10
   mod$update_state(state = new_state[1], index = 1)
   state <- mod$state()
@@ -203,7 +205,7 @@ test_that("Can update state with a matrix and index", {
   mod <- gen$new(pars, 0, n_particles)
   res <- vapply(1:10, function(t) mod$run(t),
                 matrix(0.0, 3, n_particles))
-  prev_state <- res[, 1, 10]
+  prev_state <- res[1:2, 1, 10]
   new_state <- cbind(prev_state[1] + 10, prev_state[1] + 11, prev_state[1] + 12)
   mod$update_state(state = new_state, index = 1)
   state <- mod$state()
@@ -240,7 +242,7 @@ test_that("Nothing happens if any arguments are invalid", {
                                             r2 = 0.2,
                                             K1 = 200,
                                             K2 = 200)),
-               "Expected 'state' to be a vector of length 2 but was length 4")
+               "Expected a vector of length 2 for 'state' but given 4")
   expect_equal(mod$time(), initial_time)
   expect_equal(mod$pars(), initial_pars)
 
@@ -250,10 +252,12 @@ test_that("Nothing happens if any arguments are invalid", {
                                             r2 = 0.2,
                                             K1 = 200,
                                             K2 = 200)),
-                                "Expected 'time' to be a scalar value")
+               "Expected 'time' to be scalar")
   expect_equal(mod$state(), initial_state)
   expect_equal(mod$pars(), initial_pars)
 
+  ## TODO: this one still fails, not sure how we get away with this in
+  ## dust?
   expect_error(mod$update_state(pars = list(r3 = 1),
                                 state = c(1, 2),
                                 time = 5))
@@ -287,7 +291,7 @@ test_that("Can update pars", {
 
   expect_equal(mod$state(), y2)
 
-  mod$update_state(time = 1, pars = new_pars, state = y1)
+  mod$update_state(time = 1, pars = new_pars, state = y1[1:2, ])
   expect_equal(mod$state(), y1)
   expect_equal(mod$time(), 1)
   expect_equal(mod$pars(), new_pars)
@@ -301,7 +305,8 @@ test_that("Can update pars", {
   expect_true(all(y2 == y3))
 })
 
-test_that("Updating pars set initial state by default", {
+## TODO: double check we have the same behaviour here as dust
+test_that("Updating pars set initial state if required", {
   path <- mode_file("examples/logistic.cpp")
   gen <- mode(path, quiet = TRUE)
   initial_r <- c(0.1, 0.2)
@@ -316,7 +321,7 @@ test_that("Updating pars set initial state by default", {
   new_k <- c(200, 200)
   new_pars <- list(r1 = initial_r[[1]], r2 = initial_r[[2]],
                    K1 = new_k[[1]], K2 = new_k[[2]])
-  mod$update_state(pars = new_pars)
+  mod$update_state(pars = new_pars, set_initial_state = TRUE)
   expect_equal(mod$pars(), new_pars)
   expect_equal(mod$state(1:2), matrix(1, ncol = n_particles, nrow = 2))
 })
@@ -440,7 +445,11 @@ test_that("Can update time with integer value", {
   expect_equal(mod$time(), initial_time)
   res <- mod$run(5)
   expect_equal(mod$time(), 5)
-  mod$update_state(time = as.integer(initial_time))
+  ## TODO: previously updating *just* time recalculated the initial
+  ## state, that feels like it was probably not a great choice, but
+  ## something to chase up on.
+  mod$update_state(time = as.integer(initial_time), pars = pars,
+                   set_initial_state = TRUE)
   expect_equal(mod$time(), initial_time)
   res2 <- mod$run(5)
   expect_identical(res, res2)

--- a/tests/testthat/test-updating-state.R
+++ b/tests/testthat/test-updating-state.R
@@ -8,7 +8,7 @@ test_that("Can update time", {
   expect_equal(mod$time(), initial_time)
   res <- mod$run(5)
   expect_equal(mod$time(), 5)
-  mod$update_state(time = initial_time)
+  mod$update_state(time = initial_time, pars = pars)
   expect_equal(mod$time(), initial_time)
   res2 <- mod$run(5)
   expect_identical(res, res2)
@@ -256,8 +256,6 @@ test_that("Nothing happens if any arguments are invalid", {
   expect_equal(mod$state(), initial_state)
   expect_equal(mod$pars(), initial_pars)
 
-  ## TODO: this one still fails, not sure how we get away with this in
-  ## dust?
   expect_error(mod$update_state(pars = list(r3 = 1),
                                 state = c(1, 2),
                                 time = 5))


### PR DESCRIPTION
Fairly noisy PR here:

* added some special comments for the examples, as dust will expect these
* small tweaks all over with `n_variables`, `n_state_full` and `n_state_run`; this will remain one of the pain points with the merge clearly
* move the logic around for updating the state to match the approach, errors and exact logic in dust:
   - this does affect when the initial state is calculated, and I've removed (for now) the ability to pass in a vector/matrix that matches the full variables+output (there's no analogue of this for dust which has no output variables).
* there's a bit of simplification about when `initialise()` is called on the stepper, as this recomputes the derivative again at the current point
* finally, some of the stepper methods could be simplified so I did this while I had the whole thing in my head (c47408a)